### PR TITLE
Fix token validation and infinite loops

### DIFF
--- a/custom_components/aula/aula_calendar_coordinator.py
+++ b/custom_components/aula/aula_calendar_coordinator.py
@@ -158,6 +158,8 @@ class AulaCalendarCoordinator(DataUpdateCoordinator[AulaCalendarCoordinatorData]
         try:
             logindata = self._client.login()
             self.aula_version = logindata.api_version
+        except AulaCredentialError:
+            raise
         except Exception as ex:
             _LOGGER.error(f"Login failed: {ex}")
             return ex

--- a/custom_components/aula/aula_client.py
+++ b/custom_components/aula/aula_client.py
@@ -135,11 +135,13 @@ class AulaClient:
         start_datetime: datetime.datetime,
         end_datetime: datetime.datetime,
     ) -> List[AulaBirthdayEvent]:
+        self._ensure_valid_token()
         return self._proxy.get_birthday_events(profiles, start_datetime, end_datetime)
 
     def get_daily_overviews(
         self, profiles: List[AulaProfile]
     ) -> List[AulaDailyOverview]:
+        self._ensure_valid_token()
         return self._proxy.get_daily_overviews(profiles)
 
     def get_calendar_events(
@@ -148,14 +150,17 @@ class AulaClient:
         start_datetime: datetime.datetime,
         end_datetime: datetime.datetime,
     ) -> List[AulaCalendarEvent]:
+        self._ensure_valid_token()
         return self._proxy.get_calendar_events(profiles, start_datetime, end_datetime)
 
     def get_message_threads(self) -> List[AulaMessageThread]:
+        self._ensure_valid_token()
         return self._proxy.get_message_threads()
 
     def get_notifications(
         self, profiles: List[AulaChildProfile]
     ) -> List[AULA_NOTIFICATION_TYPES]:
+        self._ensure_valid_token()
         return self._proxy.get_notifications(profiles)
 
     def get_weekly_plans(
@@ -164,6 +169,7 @@ class AulaClient:
         start_datetime: datetime.datetime,
         end_datetime: datetime.datetime,
     ) -> List[AulaWeeklyPlan]:
+        self._ensure_valid_token()
         return self._proxy.get_weekly_plans(profiles, start_datetime, end_datetime)
 
     def get_easyiq_weekly_plans(
@@ -172,6 +178,7 @@ class AulaClient:
         start_datetime: datetime.datetime,
         end_datetime: datetime.datetime,
     ) -> List[AulaEasyiqWeeklyPlan]:
+        self._ensure_valid_token()
         return self._proxy.get_easyiq_weekly_plans(
             profiles, start_datetime, end_datetime
         )
@@ -182,4 +189,5 @@ class AulaClient:
         start_datetime: datetime.datetime,
         end_datetime: datetime.datetime,
     ) -> List[AulaWeeklyNewsletter]:
+        self._ensure_valid_token()
         return self._proxy.get_newsletters(profiles, start_datetime, end_datetime)

--- a/custom_components/aula/aula_data_coordinator.py
+++ b/custom_components/aula/aula_data_coordinator.py
@@ -136,6 +136,8 @@ class AulaDataCoordinator(DataUpdateCoordinator[AulaDataCoordinatorData]):
             logindata = self._client.login()
             profiles = logindata.profiles
             self.aula_version = logindata.api_version
+        except AulaCredentialError:
+            raise
         except Exception as ex:
             _LOGGER.error(f"Login failed: {ex}")
             return ex

--- a/custom_components/aula/aula_proxy/aula_proxy_client.py
+++ b/custom_components/aula/aula_proxy/aula_proxy_client.py
@@ -531,7 +531,9 @@ class AulaProxyClient:
             if response == None or response.status_code != HTTPStatus.OK:
                 if response is not None:
                     _LOGGER.error(f"Failed to retrieve weekly plans from children: {child_userids_as_str_list} from {from_datetime} to {to_datetime}. Error: {response.status_code}/{response.reason} - {response.text}. Request: {_redact_url(response.request.url)}.")
-                    if not first_run: continue
+                    if not first_run:
+                        from_datetime += timedelta(weeks=1)
+                        continue
                     self._raise_error(response)
                 return []
             responsedata = response.json()
@@ -666,7 +668,8 @@ class AulaProxyClient:
                     _LOGGER.error(f"Failed to retrieve newsletters from children: {child_userids_as_str_list} from {from_datetime} to {to_datetime}. Error: {response.status_code}/{response.reason} - {response.text}.")
                     if first_run:
                         self._raise_error(response)
-                    continue
+                from_datetime += timedelta(weeks=1)
+                first_run = False
                 continue
             responsedata: AulaGetWeeklyNewsletterResponse = response.json()
             newsletters.extend(AulaNewsletterParser.parse_response(responsedata, from_date))


### PR DESCRIPTION
## Summary
- **Add `_ensure_valid_token()` to all 8 AulaClient data methods** — prevents widget APIs from receiving stale Aula session tokens, which caused false 401 errors and incorrect MitID reauth prompts
- **Add `AulaCredentialError` re-raise in coordinator login blocks** — ensures real credential errors (403) propagate correctly to trigger reauth instead of being swallowed by generic `except Exception`
- **Fix infinite loop in `get_weekly_plans`** — error path was missing `from_datetime` increment before `continue`
- **Fix infinite loop in `get_newsletters`** — restructured error path to always increment `from_datetime`

## Root cause
The Aula access_token could expire mid-coordinator-cycle (coordinators run 5-10 min). Widget methods (`get_weekly_plans`, `get_newsletters`, etc.) would then call `_refresh_token` against an expired Aula session, receiving garbage widget tokens. Subsequent widget API calls failed with 401, which propagated as `AulaCredentialError` → `ConfigEntryAuthFailed` → MitID reauth prompt — even though the real issue was just a stale session, not invalid credentials.

## Test plan
- [x] All 14 unit tests pass
- [ ] Verify no MitID reauth prompt on normal token expiration
- [ ] Verify MitID reauth still triggers on real credential failure (403)
- [ ] Verify weekly plans and newsletters don't hang on API errors

Fixes #2, fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)