### PR TITLE
Fix false MitID re-authentication prompts

### DIFF
--- a/custom_components/aula/aula_calendar_coordinator.py
+++ b/custom_components/aula/aula_calendar_coordinator.py
@@ -260,7 +260,13 @@ class AulaCalendarCoordinator(DataUpdateCoordinator[AulaCalendarCoordinatorData]
     #region Birthdays
 
     async def get_birthdays_for_interval(self, profiles: List[AulaChildProfile], start_datetime: datetime.datetime, end_datetime: datetime.datetime) -> List[AulaBirthdayEvent]:
-        return await self.hass.async_add_executor_job(self._client.get_birthday_events, profiles, start_datetime, end_datetime)
+        try:
+            return await self.hass.async_add_executor_job(self._client.get_birthday_events, profiles, start_datetime, end_datetime)
+        except AulaCredentialError as err:
+            raise ConfigEntryAuthFailed from err
+        except Exception as ex:
+            _LOGGER.warning("Failed to fetch birthdays for interval: %s", ex)
+            return []
 
     def get_birthdays(self, profile: AulaChildProfile) -> List[AulaBirthdayEvent]:
         key = profile.id
@@ -308,7 +314,13 @@ class AulaCalendarCoordinator(DataUpdateCoordinator[AulaCalendarCoordinatorData]
     #region Events
 
     async def get_events_for_interval(self, profiles: List[AulaInstitutionProfile], start_date: datetime.datetime, end_date: datetime.datetime) -> List[AulaCalendarEvent]:
-        return await self.hass.async_add_executor_job(self._client.get_calendar_events, profiles, start_date, end_date)
+        try:
+            return await self.hass.async_add_executor_job(self._client.get_calendar_events, profiles, start_date, end_date)
+        except AulaCredentialError as err:
+            raise ConfigEntryAuthFailed from err
+        except Exception as ex:
+            _LOGGER.warning("Failed to fetch events for interval: %s", ex)
+            return []
 
     def get_events(self, profile: AulaInstitutionProfile) -> List[AulaCalendarEvent]:
         key = profile.id
@@ -354,7 +366,13 @@ class AulaCalendarCoordinator(DataUpdateCoordinator[AulaCalendarCoordinatorData]
     #region Weekly Plans
 
     async def get_weekly_plans_for_interval(self, profiles: List[AulaChildProfile], start_datetime: datetime.datetime, end_datetime: datetime.datetime) -> List[AulaWeeklyPlan]:
-        return await self.hass.async_add_executor_job(self._client.get_weekly_plans, profiles, start_datetime, end_datetime)
+        try:
+            return await self.hass.async_add_executor_job(self._client.get_weekly_plans, profiles, start_datetime, end_datetime)
+        except AulaCredentialError as err:
+            raise ConfigEntryAuthFailed from err
+        except Exception as ex:
+            _LOGGER.warning("Failed to fetch weekly plans for interval: %s", ex)
+            return []
 
     def get_weekly_plans(self, profile: AulaChildProfile) -> List[AulaWeeklyPlan]:
         key = profile.id
@@ -402,7 +420,13 @@ class AulaCalendarCoordinator(DataUpdateCoordinator[AulaCalendarCoordinatorData]
     #region EasyIQ Weekly Plans
 
     async def get_easyiq_weekly_plans_for_interval(self, profiles: List[AulaChildProfile], start_datetime: datetime.datetime, end_datetime: datetime.datetime) -> List[AulaEasyiqWeeklyPlan]:
-        return await self.hass.async_add_executor_job(self._client.get_easyiq_weekly_plans, profiles, start_datetime, end_datetime)
+        try:
+            return await self.hass.async_add_executor_job(self._client.get_easyiq_weekly_plans, profiles, start_datetime, end_datetime)
+        except AulaCredentialError as err:
+            raise ConfigEntryAuthFailed from err
+        except Exception as ex:
+            _LOGGER.warning("Failed to fetch EasyIQ weekly plans for interval: %s", ex)
+            return []
 
     def get_easyiq_weekly_plans(self, profile: AulaChildProfile) -> List[AulaEasyiqWeeklyPlan]:
         key = profile.id
@@ -449,7 +473,13 @@ class AulaCalendarCoordinator(DataUpdateCoordinator[AulaCalendarCoordinatorData]
     #region Newsletters (MinUddannelse)
 
     async def get_newsletters_for_interval(self, profiles: List[AulaChildProfile], start_datetime: datetime.datetime, end_datetime: datetime.datetime) -> List[AulaWeeklyNewsletter]:
-        return await self.hass.async_add_executor_job(self._client.get_newsletters, profiles, start_datetime, end_datetime)
+        try:
+            return await self.hass.async_add_executor_job(self._client.get_newsletters, profiles, start_datetime, end_datetime)
+        except AulaCredentialError as err:
+            raise ConfigEntryAuthFailed from err
+        except Exception as ex:
+            _LOGGER.warning("Failed to fetch newsletters for interval: %s", ex)
+            return []
 
     def get_newsletters(self, profile: AulaChildProfile) -> List[AulaWeeklyNewsletter]:
         key = profile.id

--- a/custom_components/aula/aula_client.py
+++ b/custom_components/aula/aula_client.py
@@ -83,14 +83,21 @@ class AulaClient:
 
         Used as a callback by AulaProxyClient when it receives a 401 from the
         Aula API after the token was already validated — i.e. a transient
-        server-side issue.  Returns True on success, False on any failure.
+        server-side issue.  Returns True on success, False on transient failure.
+
+        Raises:
+            AulaCredentialError: If credentials are permanently invalid
+                (expired refresh token, no refresh token). This must propagate
+                to the coordinator so reauth is triggered immediately.
         """
         self._expires_at = 0  # Force the expiry check to trigger a refresh
         try:
             self._ensure_valid_token()
             return True
+        except AulaCredentialError:
+            raise  # Permanent credential failure — must trigger reauth
         except Exception:
-            _LOGGER.debug("Forced token refresh failed", exc_info=True)
+            _LOGGER.debug("Forced token refresh failed (transient)", exc_info=True)
             return False
 
     def _ensure_valid_token(self) -> None:

--- a/custom_components/aula/aula_client.py
+++ b/custom_components/aula/aula_client.py
@@ -52,6 +52,7 @@ class AulaClient:
         self._token_update_callback = token_update_callback
         self._token_lock = threading.Lock()
         self._proxy = AulaProxyClient(access_token, username_for_meebook=mitid_username)
+        self._proxy.set_token_refresh_callback(self._force_refresh_access_token)
 
     def close(self) -> None:
         """Close HTTP sessions."""
@@ -77,6 +78,21 @@ class AulaClient:
         self._ensure_valid_token()
         return self._proxy.login()
 
+    def _force_refresh_access_token(self) -> bool:
+        """Force-refresh the access token, bypassing the expiry check.
+
+        Used as a callback by AulaProxyClient when it receives a 401 from the
+        Aula API after the token was already validated — i.e. a transient
+        server-side issue.  Returns True on success, False on any failure.
+        """
+        self._expires_at = 0  # Force the expiry check to trigger a refresh
+        try:
+            self._ensure_valid_token()
+            return True
+        except Exception:
+            _LOGGER.debug("Forced token refresh failed", exc_info=True)
+            return False
+
     def _ensure_valid_token(self) -> None:
         """Check token expiration and refresh if needed. Thread-safe."""
         if time.time() < self._expires_at - TOKEN_REFRESH_BUFFER_SECONDS:
@@ -86,6 +102,10 @@ class AulaClient:
             # Double-check after acquiring lock — another thread may have refreshed
             if time.time() < self._expires_at - TOKEN_REFRESH_BUFFER_SECONDS:
                 return
+
+            # Guard: no refresh token means we genuinely need re-authentication
+            if not self._refresh_token:
+                raise AulaCredentialError("No refresh token available, re-authentication required")
 
             _LOGGER.debug("Access token expired or expiring soon, attempting refresh")
             self._login_client.tokens = {
@@ -106,7 +126,11 @@ class AulaClient:
                 raise ConnectionError(f"Network error during token refresh: {err}") from err
 
             if not success:
-                raise AulaCredentialError("Token refresh rejected by server")
+                # renew_access_token() returns False for transient issues (malformed
+                # server response, unexpected HTTP status, generic exceptions) — these
+                # are NOT credential rejections and must NOT trigger MitID reauth.
+                _LOGGER.warning("Token refresh returned False — treating as transient failure")
+                raise ConnectionError("Token refresh failed — server returned an unexpected response")
 
             # Extract all new values before updating state
             new_access = self._login_client.tokens["access_token"]

--- a/custom_components/aula/aula_proxy/aula_errors.py
+++ b/custom_components/aula/aula_proxy/aula_errors.py
@@ -7,3 +7,9 @@ class AulaCredentialError(Exception):
     """
     Exception raised when the credentials were rejected.
     """
+
+class AulaApiError(Exception):
+    """
+    Exception raised for non-credential API errors (e.g., unexpected HTTP status codes).
+    Unlike AulaCredentialError, this does NOT trigger MitID re-authentication.
+    """

--- a/custom_components/aula/aula_proxy/aula_proxy_client.py
+++ b/custom_components/aula/aula_proxy/aula_proxy_client.py
@@ -2,13 +2,13 @@ import calendar
 from http import HTTPStatus
 from requests import Response, Session
 from requests.exceptions import ConnectionError as RequestsConnectionError, Timeout as RequestsTimeout
-from typing import Any, Dict, Iterable, List
+from typing import Any, Callable, Dict, Iterable, List
 from datetime import datetime, timedelta, date
 import json
 import logging
 import re
 import pytz
-from .aula_errors import ParseError, AulaCredentialError
+from .aula_errors import ParseError, AulaCredentialError, AulaApiError
 from .models.constants import AulaWidgetId
 from .models.module import *
 from .responses.get_daily_overview_response import AulaGetDailyOverviewResponse
@@ -77,12 +77,17 @@ class AulaProxyClient:
     _apiurl:str = ""
     _username:str = ""
     _session:_TokenSession
+    _token_refresh_callback: Callable[[], bool] | None = None
 
     def __init__(self, access_token: str, username_for_meebook: str = ""):
         self._username = username_for_meebook
         self._session = _TokenSession()
         self._session.set_access_token(access_token)
         self._tokens = dict()
+
+    def set_token_refresh_callback(self, callback: Callable[[], bool]) -> None:
+        """Set a callback that force-refreshes the access token. Returns True on success."""
+        self._token_refresh_callback = callback
 
     def update_token(self, new_token: str) -> None:
         """Update the access token used for API calls."""
@@ -269,6 +274,7 @@ class AulaProxyClient:
                 continue
             if not self._should_retry_request(response, attempt):
                 break
+        response = self._retry_on_401(response, lambda: self._session.get(requesturl, headers=headers, verify=True))
         if response == None or response.status_code != HTTPStatus.OK:
             if response is not None:
                 _LOGGER.error(f"Failed to retrieve birthday events for profile codes: {inst_profile_codes}. Error: {response.status_code}/{response.reason} - {response.text}. Request url: {_redact_url(response.request.url)}, Request headers: {response.request.headers}, Request body: {response.request.body}.")
@@ -317,6 +323,7 @@ class AulaProxyClient:
                 continue
             if not self._should_retry_request(response, attempt):
                 break
+        response = self._retry_on_401(response, lambda: self._session.post(requesturl, json=post_data, headers=headers, verify=True))
         if response == None or response.status_code != HTTPStatus.OK:
             if response is not None:
                 _LOGGER.error(f"Failed to retrieve calendar events for profileids: {inst_profile_ids}. Error: {response.status_code}/{response.reason} - {response.text}. Request: {_redact_url(response.request.url)}.")
@@ -353,6 +360,7 @@ class AulaProxyClient:
                 continue
             if not self._should_retry_request(response, attempt):
                 break
+        response = self._retry_on_401(response, lambda: self._session.get(requesturl, headers=headers, verify=True))
         if response == None or response.status_code != HTTPStatus.OK:
             if response is not None:
                 _LOGGER.error(f"Failed to retrieve daily overview for childids: {child_ids_as_str_list}. Error: {response.status_code}/{response.reason} - {response.text}. Request: {_redact_url(response.request.url)}.")
@@ -391,6 +399,7 @@ class AulaProxyClient:
                 continue
             if not self._should_retry_request(response, attempt):
                 break
+        response = self._retry_on_401(response, lambda: self._session.get(requesturl, headers=headers, verify=True))
         if response == None or response.status_code != HTTPStatus.OK:
             if response is not None:
                 _LOGGER.error(f"Failed to retrieve message threads. Error: {response.status_code}/{response.reason} - {response.text}. Request: {_redact_url(response.request.url)}.")
@@ -415,7 +424,7 @@ class AulaProxyClient:
 
         Raises
             PermissionError: If the thread is marked as sensitive or if access is forbidden.
-            ImportError: If the status code of the response is not OK.
+            AulaApiError: If the status code of the response is not OK.
         """
         _LOGGER.debug(f"Fetching messages")
         if not thread: return []
@@ -433,6 +442,7 @@ class AulaProxyClient:
                 continue
             if not self._should_retry_request(response, attempt):
                 break
+        response = self._retry_on_401(response, lambda: self._session.get(requesturl, headers=headers, verify=True))
         if response == None or response.status_code != HTTPStatus.OK:
             if response is not None:
                 _LOGGER.error(f"Failed to retrieve messages from thread: {thread.subject} (id {thread.id}). Error: {response.status_code}/{response.reason} - {response.text}. Request: {_redact_url(response.request.url)}.")
@@ -471,6 +481,7 @@ class AulaProxyClient:
                 continue
             if not self._should_retry_request(response, attempt):
                 break
+        response = self._retry_on_401(response, lambda: self._session.get(requesturl, headers=headers, verify=True))
         if response == None or response.status_code != HTTPStatus.OK:
             if response is not None:
                 _LOGGER.error(f"Failed to retrieve notifications from children: {child_userids_as_str_list}. Error: {response.status_code}/{response.reason} - {response.text}. Request: {_redact_url(response.request.url)}.")
@@ -534,6 +545,9 @@ class AulaProxyClient:
                     if not first_run:
                         from_datetime += timedelta(weeks=1)
                         continue
+                    # Widget token failure — don't trigger main session reauth
+                    if response.status_code == HTTPStatus.UNAUTHORIZED:
+                        raise AulaApiError(f"Widget {widgetid} returned HTTP 401 after token refresh")
                     self._raise_error(response)
                 return []
             responsedata = response.json()
@@ -613,6 +627,9 @@ class AulaProxyClient:
                         if response is not None:
                             _LOGGER.error(f"Failed to retrieve EasyIQ weekplan for child {child.first_name}. Error: {response.status_code}/{response.reason} - {response.text}.")
                             if first_run:
+                                # Widget token failure — don't trigger main session reauth
+                                if response.status_code == HTTPStatus.UNAUTHORIZED:
+                                    raise AulaApiError(f"Widget {widgetid} returned HTTP 401 after token refresh")
                                 self._raise_error(response)
                             continue
                         continue
@@ -667,6 +684,9 @@ class AulaProxyClient:
                 if response is not None:
                     _LOGGER.error(f"Failed to retrieve newsletters from children: {child_userids_as_str_list} from {from_datetime} to {to_datetime}. Error: {response.status_code}/{response.reason} - {response.text}.")
                     if first_run:
+                        # Widget token failure — don't trigger main session reauth
+                        if response.status_code == HTTPStatus.UNAUTHORIZED:
+                            raise AulaApiError(f"Widget {widgetid} returned HTTP 401 after token refresh")
                         self._raise_error(response)
                 from_datetime += timedelta(weeks=1)
                 first_run = False
@@ -758,8 +778,11 @@ class AulaProxyClient:
                 return token
             responsedata = response.json()
             data = responsedata["data"]
+            if not isinstance(data, str):
+                _LOGGER.warning("Widget token response for %s contained non-string data (%s), skipping: %s", widgetid, type(data).__name__, data)
+                return token
             token = AulaToken(
-                bearer_token = "Bearer " + str(data),
+                bearer_token = "Bearer " + data,
                 timestamp = datetime.now(pytz.utc)
             )
             self._tokens[widgetid] = token
@@ -936,6 +959,23 @@ class AulaProxyClient:
                 return True
         return False
 
+    def _retry_on_401(self, response: Response | None, request_fn: Callable[[], Response]) -> Response | None:
+        """If response is 401, force-refresh the access token and retry once.
+
+        This prevents transient 401s (e.g. token propagation delays on
+        the server side) from triggering a full MitID re-authentication.
+        """
+        if (response is not None
+            and response.status_code == HTTPStatus.UNAUTHORIZED
+            and self._token_refresh_callback is not None
+            and self._token_refresh_callback()):
+            _LOGGER.debug("Got 401, retrying after access token refresh")
+            try:
+                return request_fn()
+            except (RequestsTimeout, RequestsConnectionError):
+                _LOGGER.debug("Retry after token refresh failed with network error")
+        return response
+
     @staticmethod
     def _raise_error(response: Response | None) -> None:
         if response is None: return
@@ -956,4 +996,4 @@ class AulaProxyClient:
             raise AulaCredentialError(message)
         if response.status_code == HTTPStatus.PAYMENT_REQUIRED: raise PermissionError(message)
         if response.status_code == HTTPStatus.FORBIDDEN: raise PermissionError(message)
-        raise ImportError(message)
+        raise AulaApiError(message)

--- a/custom_components/aula/aula_proxy/aula_proxy_client.py
+++ b/custom_components/aula/aula_proxy/aula_proxy_client.py
@@ -151,8 +151,13 @@ class AulaProxyClient:
         _LOGGER.debug("Logging in with token-based auth")
         self._is_logged_in = False
         if self._session and self._apiurl:
-            login_responsedata = self._session.get(self._apiurl + "?method=profiles.getProfilesByLogin", verify=True).json()
-            self._is_logged_in = login_responsedata["status"]["message"] == "OK"
+            try:
+                login_response = self._session.get(self._apiurl + "?method=profiles.getProfilesByLogin", verify=True)
+                if login_response.status_code == HTTPStatus.OK:
+                    login_responsedata = login_response.json()
+                    self._is_logged_in = login_responsedata["status"]["message"] == "OK"
+            except (json.JSONDecodeError, KeyError, RequestsTimeout, RequestsConnectionError) as e:
+                _LOGGER.debug("Quick login check failed, will proceed with full login: %s", e)
 
         _LOGGER.debug(f"Logged in already? {self._is_logged_in}")
 
@@ -198,48 +203,61 @@ class AulaProxyClient:
             # PROFILE CONTEXT (widgets & set user ids on profiles and children)
             api_method_context = "profiles.getProfileContext"
             response =  self._session.get(f"{self._apiurl}?method={api_method_context}&portalrole=guardian",verify=True)
-            responsedata_context: AulaGetProfileContextResponse = response.json()
-            data = responsedata_context["data"]
-            #set user id on logged in profile
-            userid = data["userId"]
-            for profile in profiles:
-                profile.user_id = userid
+            if response.status_code == HTTPStatus.FORBIDDEN:
+                raise AulaCredentialError(f"Access denied for {api_method_context}")
+            if response.status_code != HTTPStatus.OK:
+                _LOGGER.warning(f"Failed to fetch {api_method_context}: HTTP {response.status_code}, some data may be missing")
+            else:
+                try:
+                    responsedata_context: AulaGetProfileContextResponse = response.json()
+                    data = responsedata_context["data"]
+                    #set user id on logged in profile
+                    userid = data["userId"]
+                    for profile in profiles:
+                        profile.user_id = userid
 
-            #set user id on children profiles
-            children = dict((child.id, child) for child in self.flatten_children(profiles))
-            institutions = None if "institutions" not in data else data["institutions"]
-            if institutions:
-                for institutiondata in institutions:
-                    if "children" in institutiondata and institutiondata["children"] is not None:
-                        for childdata in institutiondata["children"]:
-                            child = children.get(childdata["id"])
-                            if child: child.user_id = childdata["userId"]
+                    #set user id on children profiles
+                    children = dict((child.id, child) for child in self.flatten_children(profiles))
+                    institutions = None if "institutions" not in data else data["institutions"]
+                    if institutions:
+                        for institutiondata in institutions:
+                            if "children" in institutiondata and institutiondata["children"] is not None:
+                                for childdata in institutiondata["children"]:
+                                    child = children.get(childdata["id"])
+                                    if child: child.user_id = childdata["userId"]
 
-            #read widgets (used to identify supported features)
-            detected_widgetsdata = responsedata_context["data"]["pageConfiguration"]["widgetConfigurations"]
-            try:
-                widgets = AulaProfileParser.parse_widgets([widgetconfdata["widget"] for widgetconfdata in detected_widgetsdata])
-            except Exception as e:
-                _LOGGER.info(f"method={api_method_context} response: {responsedata_context}")
-                _LOGGER.error(f"Error parsing widgets: {e}")
+                    #read widgets (used to identify supported features)
+                    detected_widgetsdata = responsedata_context["data"]["pageConfiguration"]["widgetConfigurations"]
+                    try:
+                        widgets = AulaProfileParser.parse_widgets([widgetconfdata["widget"] for widgetconfdata in detected_widgetsdata])
+                    except Exception as e:
+                        _LOGGER.info(f"method={api_method_context} response: {responsedata_context}")
+                        _LOGGER.error(f"Error parsing widgets: {e}")
+                except (json.JSONDecodeError, KeyError, TypeError) as e:
+                    _LOGGER.warning(f"Failed to parse {api_method_context} response: {e}")
 
         if len(profiles) > 0:
             # PROFILE MASTER DATA (set master group on children)
             api_method_masterdata = "profiles.getProfileMasterData"
             inst_profile_ids = list(set(str(institution_profile.id) for profile in profiles for institution_profile in profile.institution_profiles))
             response = self._session.get(f"{self._apiurl}?method={api_method_masterdata}&instProfileIds[]={"&instProfileIds[]=".join(inst_profile_ids)}&fromAdministration=false",verify=True)
-            responsedata_masterdata: AulaGetProfileMasterDataResponse = response.json()
-            #set master group on children profiles
-            relations = AulaProfileParser.parse_profile_master_data_response(responsedata_masterdata)
-            children = dict((child.id, child) for child in self.flatten_children(profiles))
+            if response.status_code != HTTPStatus.OK:
+                _LOGGER.warning(f"Failed to fetch {api_method_masterdata}: HTTP {response.status_code}, master group data may be missing")
+            else:
+                try:
+                    responsedata_masterdata: AulaGetProfileMasterDataResponse = response.json()
+                    #set master group on children profiles
+                    relations = AulaProfileParser.parse_profile_master_data_response(responsedata_masterdata)
+                    children = dict((child.id, child) for child in self.flatten_children(profiles))
 
-            try:
-                for relation in relations:
-                    child = children.get(relation.child_id)
-                    if child: child.main_group = relation.main_group
-            except Exception as e:
-                _LOGGER.info(f"method={api_method_masterdata} response: {responsedata_masterdata}")
-                _LOGGER.error(f"Error assigning main groups: {e}")
+                    for relation in relations:
+                        child = children.get(relation.child_id)
+                        if child: child.main_group = relation.main_group
+                except (json.JSONDecodeError, KeyError, TypeError) as e:
+                    _LOGGER.warning(f"Failed to parse {api_method_masterdata} response: {e}")
+                except Exception as e:
+                    _LOGGER.info(f"method={api_method_masterdata} response: {response.text}")
+                    _LOGGER.error(f"Error assigning main groups: {e}")
 
         result = AulaLoginData(
             profiles = profiles,
@@ -573,7 +591,10 @@ class AulaProxyClient:
             for profile in self._login_result.profiles:
                 if profile.user_id:
                     return profile.user_id
-        responsedata = self._session.get(f"{self._apiurl}?method=profiles.getProfileContext&portalrole=guardian", verify=True).json()
+        response = self._session.get(f"{self._apiurl}?method=profiles.getProfileContext&portalrole=guardian", verify=True)
+        if response.status_code != HTTPStatus.OK:
+            raise AulaApiError(f"Failed to fetch guardian user ID: HTTP {response.status_code}")
+        responsedata = response.json()
         return responsedata["data"]["userId"]
 
     def get_easyiq_weekly_plans(self, profiles: List[AulaChildProfile], from_datetime: datetime, to_datetime: datetime) -> List[AulaEasyiqWeeklyPlan]:
@@ -801,27 +822,6 @@ class AulaProxyClient:
                 return token
         return self._refresh_token(widgetid)
 
-    def _get_user_id(self, profiles: List[AulaProfile]) -> str:
-        """Ensures that each profile in the provided list has a user_id by fetching it from the API."""
-        currentid: str|None = None
-        for profile in profiles:
-            if profile.user_id:
-                currentid = profile.user_id
-            else:
-                currentid = None
-                break
-
-        if currentid is not None:
-            return currentid
-
-        responsedata = self._session.get(f"{self._apiurl}?method=profiles.getProfileContext&portalrole=guardian",verify=True,).json()
-        newid = responsedata["data"]["userId"]
-
-        for profile in profiles:
-            profile.user_id = newid
-
-        return newid
-
     def has_widget(self, widget_match: AulaWidgetId) -> bool:
         widgets = [] if self._login_result is None else self._login_result.widgets
         return any(widget.widget_id == widget_match for widget in widgets)
@@ -964,17 +964,31 @@ class AulaProxyClient:
 
         This prevents transient 401s (e.g. token propagation delays on
         the server side) from triggering a full MitID re-authentication.
+
+        AulaCredentialError from the callback (permanent credential failure)
+        is allowed to propagate — the coordinator will convert it to reauth.
         """
-        if (response is not None
-            and response.status_code == HTTPStatus.UNAUTHORIZED
-            and self._token_refresh_callback is not None
-            and self._token_refresh_callback()):
-            _LOGGER.debug("Got 401, retrying after access token refresh")
-            try:
-                return request_fn()
-            except (RequestsTimeout, RequestsConnectionError):
-                _LOGGER.debug("Retry after token refresh failed with network error")
-        return response
+        if response is None or response.status_code != HTTPStatus.UNAUTHORIZED:
+            return response
+        if self._token_refresh_callback is None:
+            return response
+        # Callback may raise AulaCredentialError for permanent failures — let it propagate
+        if not self._token_refresh_callback():
+            # Transient refresh failure — don't let the original 401 trigger reauth
+            _LOGGER.warning("Access token refresh failed (transient), returning error without reauth")
+            raise ConnectionError("Access token refresh failed — could not retry after 401")
+        _LOGGER.debug("Got 401, retrying after access token refresh")
+        try:
+            retried = request_fn()
+        except (RequestsTimeout, RequestsConnectionError):
+            _LOGGER.debug("Retry after token refresh failed with network error")
+            raise ConnectionError("Request failed after token refresh (network error)")
+        if retried is not None and retried.status_code == HTTPStatus.UNAUTHORIZED:
+            # Token was JUST refreshed successfully but API still returns 401 —
+            # this is almost certainly a transient server-side issue, not dead credentials.
+            _LOGGER.warning("API returned 401 even after successful token refresh — treating as transient")
+            raise ConnectionError("API returned 401 after successful token refresh")
+        return retried
 
     @staticmethod
     def _raise_error(response: Response | None) -> None:

--- a/custom_components/aula/aula_proxy/test_error_handling.py
+++ b/custom_components/aula/aula_proxy/test_error_handling.py
@@ -1,0 +1,402 @@
+"""Tests for error handling and 401 retry logic.
+
+Verifies the core safety property: transient errors must NOT trigger MitID
+re-authentication (AulaCredentialError / ConfigEntryAuthFailed), while genuine
+credential failures MUST still trigger it.
+"""
+import json
+import time
+import threading
+import unittest
+from http import HTTPStatus
+from unittest.mock import MagicMock, Mock, patch, PropertyMock
+
+from requests import Response
+from requests.exceptions import ConnectionError as RequestsConnectionError, Timeout as RequestsTimeout
+
+from custom_components.aula.aula_proxy.aula_errors import AulaApiError, AulaCredentialError
+from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
+
+
+def _make_response(status_code: int, json_body: dict | list | None = None, text: str = "") -> Mock:
+    """Build a mock Response with a given status code and optional JSON body."""
+    resp = Mock(spec=Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    resp.reason = HTTPStatus(status_code).phrase if status_code in [s.value for s in HTTPStatus] else ""
+    resp.text = text or json.dumps(json_body) if json_body is not None else ""
+    if json_body is not None:
+        resp.json = Mock(return_value=json_body)
+    else:
+        resp.json = Mock(side_effect=json.JSONDecodeError("", "", 0))
+    # request attribute for logging
+    req = Mock()
+    req.url = "https://example.com/api"
+    req.headers = {}
+    req.body = None
+    resp.request = req
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _retry_on_401
+# ---------------------------------------------------------------------------
+
+class TestRetryOn401(unittest.TestCase):
+    """Tests for AulaProxyClient._retry_on_401."""
+
+    def setUp(self):
+        self.client = AulaProxyClient("test-token")
+
+    def test_successful_retry_after_transient_401(self):
+        """Transient 401 → refresh succeeds → retry returns 200."""
+        resp_401 = _make_response(401)
+        resp_200 = _make_response(200, {"data": []})
+        callback = Mock(return_value=True)
+        request_fn = Mock(return_value=resp_200)
+
+        self.client.set_token_refresh_callback(callback)
+        result = self.client._retry_on_401(resp_401, request_fn)
+
+        self.assertEqual(result.status_code, 200)
+        callback.assert_called_once()
+        request_fn.assert_called_once()
+
+    def test_callback_returns_false(self):
+        """Refresh fails → returns original 401, no retry request made."""
+        resp_401 = _make_response(401)
+        callback = Mock(return_value=False)
+        request_fn = Mock()
+
+        self.client.set_token_refresh_callback(callback)
+        result = self.client._retry_on_401(resp_401, request_fn)
+
+        self.assertIs(result, resp_401)
+        request_fn.assert_not_called()
+
+    def test_no_callback_set(self):
+        """No callback → returns original response unchanged."""
+        resp_401 = _make_response(401)
+        result = self.client._retry_on_401(resp_401, Mock())
+        self.assertIs(result, resp_401)
+
+    def test_non_401_passes_through(self):
+        """Non-401 responses are returned unchanged without invoking callback."""
+        resp_500 = _make_response(500)
+        callback = Mock()
+        self.client.set_token_refresh_callback(callback)
+
+        result = self.client._retry_on_401(resp_500, Mock())
+
+        self.assertIs(result, resp_500)
+        callback.assert_not_called()
+
+    def test_none_response_passes_through(self):
+        result = self.client._retry_on_401(None, Mock())
+        self.assertIsNone(result)
+
+    def test_retry_network_error_returns_original(self):
+        """If the retry request fails with a network error, return the original 401."""
+        resp_401 = _make_response(401)
+        callback = Mock(return_value=True)
+        request_fn = Mock(side_effect=RequestsConnectionError("conn error"))
+
+        self.client.set_token_refresh_callback(callback)
+        result = self.client._retry_on_401(resp_401, request_fn)
+
+        self.assertIs(result, resp_401)
+
+    def test_retry_timeout_returns_original(self):
+        """If the retry request times out, return the original 401."""
+        resp_401 = _make_response(401)
+        callback = Mock(return_value=True)
+        request_fn = Mock(side_effect=RequestsTimeout("timeout"))
+
+        self.client.set_token_refresh_callback(callback)
+        result = self.client._retry_on_401(resp_401, request_fn)
+
+        self.assertIs(result, resp_401)
+
+
+# ---------------------------------------------------------------------------
+# _raise_error
+# ---------------------------------------------------------------------------
+
+class TestRaiseError(unittest.TestCase):
+    """Tests for AulaProxyClient._raise_error."""
+
+    def test_401_raises_credential_error(self):
+        resp = _make_response(401, {"status": {"message": "Unauthorized"}})
+        with self.assertRaises(AulaCredentialError):
+            AulaProxyClient._raise_error(resp)
+
+    def test_402_raises_permission_error(self):
+        resp = _make_response(402)
+        with self.assertRaises(PermissionError):
+            AulaProxyClient._raise_error(resp)
+
+    def test_403_raises_permission_error(self):
+        resp = _make_response(403)
+        with self.assertRaises(PermissionError):
+            AulaProxyClient._raise_error(resp)
+
+    def test_500_raises_api_error_not_credential(self):
+        """Server errors must raise AulaApiError, NOT AulaCredentialError."""
+        resp = _make_response(500)
+        with self.assertRaises(AulaApiError):
+            AulaProxyClient._raise_error(resp)
+        # Must NOT raise AulaCredentialError
+        with self.assertRaises(AulaApiError) as ctx:
+            AulaProxyClient._raise_error(resp)
+        self.assertNotIsInstance(ctx.exception, AulaCredentialError)
+
+    def test_404_raises_api_error(self):
+        resp = _make_response(404)
+        with self.assertRaises(AulaApiError):
+            AulaProxyClient._raise_error(resp)
+
+    def test_none_response_noop(self):
+        AulaProxyClient._raise_error(None)  # Should not raise
+
+    def test_ok_response_noop(self):
+        resp = _make_response(200)
+        AulaProxyClient._raise_error(resp)  # Should not raise
+
+    def test_malformed_json_uses_fallback_message(self):
+        resp = _make_response(500, text="<html>error</html>")
+        resp.json = Mock(side_effect=json.JSONDecodeError("", "", 0))
+        with self.assertRaises(AulaApiError) as ctx:
+            AulaProxyClient._raise_error(resp)
+        self.assertIn("500", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# _refresh_token data validation
+# ---------------------------------------------------------------------------
+
+class TestRefreshTokenValidation(unittest.TestCase):
+    """Tests for widget token data type validation in _refresh_token."""
+
+    def setUp(self):
+        self.client = AulaProxyClient("test-token")
+        self.client._apiurl = "https://example.com/api/v1"
+
+    def test_valid_string_token(self):
+        """String JWT data → creates proper AulaToken."""
+        resp = _make_response(200, {"data": "some-jwt-token"})
+        with patch.object(self.client._session, "get", return_value=resp):
+            from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+            token = self.client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=True)
+        self.assertIsNotNone(token)
+        self.assertEqual(token.bearer_token, "Bearer some-jwt-token")
+
+    def test_dict_data_rejected(self):
+        """Dict data (e.g. error payload) → returns old token, not garbage."""
+        resp = _make_response(200, {"data": {"error": "expired"}})
+        with patch.object(self.client._session, "get", return_value=resp):
+            from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+            token = self.client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=True)
+        # Should return None (no previous token) rather than garbage
+        self.assertIsNone(token)
+
+    def test_none_data_rejected(self):
+        """None data → returns old token."""
+        resp = _make_response(200, {"data": None})
+        with patch.object(self.client._session, "get", return_value=resp):
+            from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+            token = self.client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=True)
+        self.assertIsNone(token)
+
+    def test_int_data_rejected(self):
+        """Integer data → returns old token."""
+        resp = _make_response(200, {"data": 12345})
+        with patch.object(self.client._session, "get", return_value=resp):
+            from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+            token = self.client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=True)
+        self.assertIsNone(token)
+
+    def test_http_error_returns_old_token(self):
+        """Non-200 → returns previous token (None if no previous)."""
+        resp = _make_response(500)
+        with patch.object(self.client._session, "get", return_value=resp):
+            from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+            token = self.client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=True)
+        self.assertIsNone(token)
+
+    def test_network_error_returns_old_token(self):
+        """Network error → returns previous token."""
+        with patch.object(self.client._session, "get", side_effect=RequestsTimeout("timeout")):
+            from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+            token = self.client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=True)
+        self.assertIsNone(token)
+
+
+# ---------------------------------------------------------------------------
+# _ensure_valid_token and _force_refresh_access_token
+# ---------------------------------------------------------------------------
+
+class TestEnsureValidToken(unittest.TestCase):
+    """Tests for AulaClient._ensure_valid_token and _force_refresh_access_token."""
+
+    def _make_client(self, expires_at: float = 0, refresh_token: str = "test-refresh"):
+        from custom_components.aula.aula_client import AulaClient
+        login_client = Mock()
+        login_client.tokens = {}
+        client = AulaClient(
+            access_token="test-access",
+            refresh_token=refresh_token,
+            expires_at=expires_at,
+            mitid_username="test-user",
+            login_client=login_client,
+            token_update_callback=Mock(),
+        )
+        return client, login_client
+
+    def test_token_still_valid_no_refresh(self):
+        """Token not expired → no refresh call."""
+        client, login_client = self._make_client(expires_at=time.time() + 600)
+        client._ensure_valid_token()
+        login_client.renew_access_token.assert_not_called()
+
+    def test_expired_token_successful_refresh(self):
+        """Token expired → refresh succeeds → state updated."""
+        client, login_client = self._make_client(expires_at=0)
+
+        def renew_side_effect():
+            # Simulate the login client updating its tokens dict on success
+            login_client.tokens.update({
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "expires_at": time.time() + 3600,
+            })
+            return True
+        login_client.renew_access_token.side_effect = renew_side_effect
+
+        client._ensure_valid_token()
+
+        self.assertEqual(client._access_token, "new-access")
+        self.assertEqual(client._refresh_token, "new-refresh")
+
+    def test_no_refresh_token_raises_credential_error(self):
+        """No refresh token → MUST raise AulaCredentialError (legitimate reauth)."""
+        client, _ = self._make_client(expires_at=0, refresh_token="")
+
+        with self.assertRaises(AulaCredentialError):
+            client._ensure_valid_token()
+
+    def test_token_expired_error_raises_credential_error(self):
+        """TokenExpiredError from server → MUST raise AulaCredentialError."""
+        from custom_components.aula.aula_login_client.exceptions import TokenExpiredError
+        client, login_client = self._make_client(expires_at=0)
+        login_client.renew_access_token.side_effect = TokenExpiredError("expired")
+
+        with self.assertRaises(AulaCredentialError):
+            client._ensure_valid_token()
+
+    def test_network_error_raises_connection_error_not_credential(self):
+        """NetworkError → ConnectionError, NOT AulaCredentialError (no reauth)."""
+        from custom_components.aula.aula_login_client.exceptions import NetworkError
+        client, login_client = self._make_client(expires_at=0)
+        login_client.renew_access_token.side_effect = NetworkError("network down")
+
+        with self.assertRaises(ConnectionError):
+            client._ensure_valid_token()
+        # Verify it's not a credential error
+        try:
+            client._expires_at = 0
+            client._ensure_valid_token()
+        except AulaCredentialError:
+            self.fail("NetworkError must NOT raise AulaCredentialError")
+        except ConnectionError:
+            pass  # Expected
+
+    def test_renew_returns_false_raises_connection_error_not_credential(self):
+        """renew_access_token() returns False → ConnectionError, NOT AulaCredentialError."""
+        client, login_client = self._make_client(expires_at=0)
+        login_client.renew_access_token.return_value = False
+
+        with self.assertRaises(ConnectionError):
+            client._ensure_valid_token()
+        # Verify it's not a credential error
+        try:
+            client._expires_at = 0
+            client._ensure_valid_token()
+        except AulaCredentialError:
+            self.fail("False return must NOT raise AulaCredentialError")
+        except ConnectionError:
+            pass  # Expected
+
+    def test_force_refresh_success(self):
+        """_force_refresh_access_token returns True on successful refresh."""
+        client, login_client = self._make_client(expires_at=time.time() + 600)
+        login_client.renew_access_token.return_value = True
+        login_client.tokens = {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_at": time.time() + 3600,
+        }
+
+        result = client._force_refresh_access_token()
+
+        self.assertTrue(result)
+
+    def test_force_refresh_failure_returns_false(self):
+        """_force_refresh_access_token returns False on any failure."""
+        client, login_client = self._make_client(expires_at=0)
+        login_client.renew_access_token.return_value = False
+
+        result = client._force_refresh_access_token()
+
+        self.assertFalse(result)
+
+    def test_force_refresh_unexpected_exception_returns_false(self):
+        """_force_refresh_access_token catches unexpected exceptions."""
+        client, login_client = self._make_client(expires_at=0)
+        login_client.renew_access_token.side_effect = RuntimeError("unexpected")
+
+        result = client._force_refresh_access_token()
+
+        self.assertFalse(result)
+
+    def test_thread_safety_concurrent_refresh(self):
+        """Two threads calling _ensure_valid_token → renew called exactly once."""
+        client, login_client = self._make_client(expires_at=0)
+        call_count = 0
+
+        def slow_renew():
+            nonlocal call_count
+            call_count += 1
+            # Simulate some work
+            login_client.tokens = {
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "expires_at": time.time() + 3600,
+            }
+            return True
+
+        login_client.renew_access_token.side_effect = slow_renew
+
+        threads = []
+        errors = []
+        for _ in range(2):
+            def run():
+                try:
+                    client._ensure_valid_token()
+                except Exception as e:
+                    errors.append(e)
+            t = threading.Thread(target=run)
+            threads.append(t)
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        self.assertEqual(len(errors), 0, f"Unexpected errors: {errors}")
+        # Due to double-checked locking, renew should be called once
+        # (the second thread sees the updated _expires_at)
+        self.assertEqual(call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/custom_components/aula/aula_proxy/test_error_handling.py
+++ b/custom_components/aula/aula_proxy/test_error_handling.py
@@ -62,16 +62,15 @@ class TestRetryOn401(unittest.TestCase):
         callback.assert_called_once()
         request_fn.assert_called_once()
 
-    def test_callback_returns_false(self):
-        """Refresh fails → returns original 401, no retry request made."""
+    def test_callback_returns_false_raises_connection_error(self):
+        """Transient refresh failure → raises ConnectionError (not reauth)."""
         resp_401 = _make_response(401)
         callback = Mock(return_value=False)
         request_fn = Mock()
 
         self.client.set_token_refresh_callback(callback)
-        result = self.client._retry_on_401(resp_401, request_fn)
-
-        self.assertIs(result, resp_401)
+        with self.assertRaises(ConnectionError):
+            self.client._retry_on_401(resp_401, request_fn)
         request_fn.assert_not_called()
 
     def test_no_callback_set(self):
@@ -95,27 +94,56 @@ class TestRetryOn401(unittest.TestCase):
         result = self.client._retry_on_401(None, Mock())
         self.assertIsNone(result)
 
-    def test_retry_network_error_returns_original(self):
-        """If the retry request fails with a network error, return the original 401."""
+    def test_retry_network_error_raises_connection_error(self):
+        """If the retry request fails with a network error, raise ConnectionError (not reauth)."""
         resp_401 = _make_response(401)
         callback = Mock(return_value=True)
         request_fn = Mock(side_effect=RequestsConnectionError("conn error"))
 
         self.client.set_token_refresh_callback(callback)
-        result = self.client._retry_on_401(resp_401, request_fn)
+        with self.assertRaises(ConnectionError):
+            self.client._retry_on_401(resp_401, request_fn)
 
-        self.assertIs(result, resp_401)
-
-    def test_retry_timeout_returns_original(self):
-        """If the retry request times out, return the original 401."""
+    def test_retry_timeout_raises_connection_error(self):
+        """If the retry request times out, raise ConnectionError (not reauth)."""
         resp_401 = _make_response(401)
         callback = Mock(return_value=True)
         request_fn = Mock(side_effect=RequestsTimeout("timeout"))
 
         self.client.set_token_refresh_callback(callback)
-        result = self.client._retry_on_401(resp_401, request_fn)
+        with self.assertRaises(ConnectionError):
+            self.client._retry_on_401(resp_401, request_fn)
 
-        self.assertIs(result, resp_401)
+    def test_retry_still_401_raises_connection_error(self):
+        """If retry also returns 401, raise ConnectionError — token was just refreshed so this is transient."""
+        resp_401 = _make_response(401)
+        retry_401 = _make_response(401)
+        callback = Mock(return_value=True)
+        request_fn = Mock(return_value=retry_401)
+
+        self.client.set_token_refresh_callback(callback)
+        with self.assertRaises(ConnectionError):
+            self.client._retry_on_401(resp_401, request_fn)
+
+    def test_retry_non_401_error_returned(self):
+        """If retry returns a non-401 error (e.g. 500), return it for normal error handling."""
+        resp_401 = _make_response(401)
+        resp_500 = _make_response(500)
+        callback = Mock(return_value=True)
+        request_fn = Mock(return_value=resp_500)
+
+        self.client.set_token_refresh_callback(callback)
+        result = self.client._retry_on_401(resp_401, request_fn)
+        self.assertEqual(result.status_code, 500)
+
+    def test_callback_credential_error_propagates(self):
+        """AulaCredentialError from callback propagates (triggers reauth)."""
+        resp_401 = _make_response(401)
+        callback = Mock(side_effect=AulaCredentialError("expired"))
+
+        self.client.set_token_refresh_callback(callback)
+        with self.assertRaises(AulaCredentialError):
+            self.client._retry_on_401(resp_401, Mock())
 
 
 # ---------------------------------------------------------------------------
@@ -340,8 +368,8 @@ class TestEnsureValidToken(unittest.TestCase):
 
         self.assertTrue(result)
 
-    def test_force_refresh_failure_returns_false(self):
-        """_force_refresh_access_token returns False on any failure."""
+    def test_force_refresh_transient_failure_returns_false(self):
+        """_force_refresh_access_token returns False on transient failure (ConnectionError)."""
         client, login_client = self._make_client(expires_at=0)
         login_client.renew_access_token.return_value = False
 
@@ -349,8 +377,17 @@ class TestEnsureValidToken(unittest.TestCase):
 
         self.assertFalse(result)
 
+    def test_force_refresh_credential_error_propagates(self):
+        """_force_refresh_access_token lets AulaCredentialError propagate."""
+        from custom_components.aula.aula_login_client.exceptions import TokenExpiredError
+        client, login_client = self._make_client(expires_at=0)
+        login_client.renew_access_token.side_effect = TokenExpiredError("expired")
+
+        with self.assertRaises(AulaCredentialError):
+            client._force_refresh_access_token()
+
     def test_force_refresh_unexpected_exception_returns_false(self):
-        """_force_refresh_access_token catches unexpected exceptions."""
+        """_force_refresh_access_token catches unexpected (non-credential) exceptions."""
         client, login_client = self._make_client(expires_at=0)
         login_client.renew_access_token.side_effect = RuntimeError("unexpected")
 


### PR DESCRIPTION
## Summary
- **Eliminate false MitID reauth prompts** caused by transient 401s, widget token failures, and ambiguous token refresh errors
- Add `_retry_on_401` to all non-widget API methods: on 401, force-refresh the access token and retry once before raising an error
- Widget methods (Meebook/EasyIQ/MinUddannelse) now raise `AulaApiError` instead of `AulaCredentialError` on 401 — widget JWT issues no longer trigger main session reauth
- `_ensure_valid_token`: `renew_access_token()` returning `False` now raises `ConnectionError` (retried next poll) instead of `AulaCredentialError` (which triggered reauth)
- `_retry_on_401` is hermetically sealed: every failure path after token refresh raises `ConnectionError`, never `AulaCredentialError`
- `_force_refresh_access_token` lets `AulaCredentialError` propagate for genuinely expired credentials, only catches transient errors
- Calendar `get_*_for_interval` methods now handle errors gracefully instead of crashing
- `login()` unguarded `.json()` calls now check status codes first
- `_refresh_token` validates widget token data is a string (prevents garbage `"Bearer {'error': 'expired'}"` tokens)
- Replace misused `ImportError` with proper `AulaApiError` exception
- 49 unit tests covering retry logic, error classification, token validation, and thread safety

## Reauth now ONLY triggers when
| Path | Condition |
|------|-----------|
| No refresh token | `_ensure_valid_token` — genuinely missing |
| TokenExpiredError | Server explicitly rejected refresh token (401/403 from token endpoint) |
| login() 403 | Aula API explicitly denied access |
| getProfileContext 403 | Aula API explicitly denied access |

All transient paths (network errors, server hiccups, widget token issues, 401 after successful refresh) are `ConnectionError` → `UpdateFailed` → retried on next poll.

## Test plan
- [x] 49 unit tests pass (14 existing + 35 new)
- [x] `_retry_on_401`: success, callback failure, no callback, non-401 passthrough, network errors, still-401-after-refresh
- [x] `_raise_error`: 401/402/403/404/500, None, OK, malformed JSON
- [x] `_refresh_token`: valid string, dict, None, int, HTTP errors, network errors
- [x] `_ensure_valid_token`: valid token, expired+success, no refresh token, TokenExpiredError, NetworkError, False return
- [x] `_force_refresh_access_token`: success, transient failure, credential error propagation, unexpected exceptions
- [x] Thread safety: concurrent refresh calls use lock correctly
- [ ] Runtime verification with actual Aula API