### PR TITLE
Match upstream PR #341 widget JWT recovery; revert v0.2.6 regressions

### DIFF
--- a/custom_components/aula/aula_proxy/aula_proxy_client.py
+++ b/custom_components/aula/aula_proxy/aula_proxy_client.py
@@ -41,12 +41,14 @@ REQUEST_MAX_ATTEMPTS = 3
 """Maximum number of attempts for requests, when certain errors occurs, such as timeout."""
 REQUEST_TIMEOUT = 30
 """Default timeout in seconds for all HTTP requests."""
-TOKEN_EXPIRATION_TIME = timedelta(minutes=40)
-"""Maximum cache duration for widget tokens when JWT exp claim is unavailable."""
-TOKEN_EXPIRY_BUFFER = timedelta(seconds=60)
-"""Refresh widget tokens this many seconds before their actual JWT exp claim.
-Set to 60s to absorb clock skew between client and server (HA on devices
-without NTP can drift by tens of seconds)."""
+TOKEN_EXPIRATION_TIME = timedelta(minutes=5)
+"""Wall-clock cache duration for widget tokens. Matches coordinator polling
+cadence so each poll typically gets a fresh token. Aula's actual JWT TTL
+is unknown and unreliable — this is the simple cache scaarup/aula uses too."""
+RECOVERY_COOLDOWN = timedelta(minutes=10)
+"""Minimum interval between full recovery attempts. During a persistent Aula
+outage, repeated recoveries only churn the OAuth token endpoint without
+fixing anything. After one failed recovery, wait this long before trying again."""
 
 _ACCESS_TOKEN_PATTERN = re.compile(r'access_token=[^&\s]*')
 
@@ -138,6 +140,7 @@ class AulaProxyClient:
     _username:str = ""
     _session:_TokenSession
     _token_refresh_callback: Callable[[], bool] | None = None
+    _last_recovery_at: datetime | None = None
 
     def __init__(self, access_token: str, username_for_meebook: str = ""):
         self._username = username_for_meebook
@@ -146,6 +149,8 @@ class AulaProxyClient:
         self._tokens = dict()
         # Serialize widget token refreshes so two coordinator threads can't
         # both make HTTP roundtrips for the same widget simultaneously.
+        # Also serializes _full_recovery() to prevent two widgets both doing
+        # session reset + OAuth refresh + login concurrently.
         self._token_refresh_lock = threading.Lock()
 
     def set_token_refresh_callback(self, callback: Callable[[], bool]) -> None:
@@ -173,6 +178,89 @@ class AulaProxyClient:
     def update_token(self, new_token: str) -> None:
         """Update the access token used for API calls."""
         self._session.set_access_token(new_token)
+
+    @staticmethod
+    def _is_widget_token_expired_body(response: Response | None) -> bool:
+        """Detect Aula's 'token expired' signal embedded in a 200 OK body.
+
+        Aula occasionally returns HTTP 200 with body
+        ``{"message": "JWT-Token expired, please renew."}``
+        instead of HTTP 401. Upstream PR #341 detects this body pattern.
+        We must check both the status code AND the body content.
+        """
+        if response is None or response.status_code != HTTPStatus.OK:
+            return False
+        try:
+            body = response.json()
+        except (json.JSONDecodeError, ValueError):
+            return False
+        if not isinstance(body, dict):
+            return False
+        msg = body.get("message")
+        if not isinstance(msg, str):
+            return False
+        return "expired" in msg.lower()
+
+    def _full_recovery(self, widgetid: AulaWidgetId) -> AulaToken | None:
+        """Full recovery sequence when a widget endpoint reports the JWT
+        as expired: drop cookies + refresh OAuth access_token + re-warm
+        Aula session + fetch a fresh widget JWT.
+
+        Mirrors upstream scaarup/aula's PR #341 working approach. A simple
+        widget-token refresh is not enough because Aula's server-side
+        session is the actual cache key for the widget JWT — if cookies
+        and access_token aren't BOTH rotated, Aula keeps issuing the same
+        stale widget JWT.
+
+        The OAuth access_token refresh is a silent server-to-server call
+        (NO MitID prompt). The user is unaffected.
+
+        Cooldown: at most one full recovery per RECOVERY_COOLDOWN window
+        to prevent OAuth token churn during a persistent Aula outage.
+        Serialized via _token_refresh_lock for thread safety with other
+        coordinator threads doing concurrent widget calls.
+        """
+        with self._token_refresh_lock:
+            now = datetime.now(pytz.utc)
+            # Cooldown: skip recovery if we just did one. During a persistent
+            # Aula outage, repeated recovery attempts only spin the OAuth token
+            # endpoint without changing the result. Serve whatever cached token
+            # we have (or None) and let the widget call fail honestly.
+            if self._last_recovery_at is not None and (now - self._last_recovery_at) < RECOVERY_COOLDOWN:
+                age = (now - self._last_recovery_at).total_seconds()
+                _LOGGER.warning(
+                    "Skipping full recovery for widget %s — last recovery was %.0fs ago "
+                    "(cooldown %ss). Aula's bug appears persistent; serving cached token.",
+                    widgetid, age, RECOVERY_COOLDOWN.total_seconds(),
+                )
+                return self._tokens.get(widgetid)
+            self._last_recovery_at = now
+
+            _LOGGER.info("Triggering full recovery for widget %s (cookies + access_token + session)", widgetid)
+            # Step 1: drop cookies (preserves access_token in new session)
+            self.reset_session()
+            # Step 2: refresh OAuth access_token via callback (also calls update_token
+            # on the new proxy session). Lets AulaCredentialError propagate so
+            # genuine credential failures still trigger HA reauth.
+            if self._token_refresh_callback is not None:
+                if not self._token_refresh_callback():
+                    _LOGGER.warning(
+                        "OAuth access_token refresh returned False during widget recovery — "
+                        "continuing anyway with the existing token",
+                    )
+            # Step 3: re-warm Aula session (getProfilesByLogin sets fresh cookies
+            # AND, since reset_session cleared _login_result, full bootstrap
+            # including getProfileContext + getProfileMasterData).
+            try:
+                self.login()
+            except Exception as login_err:
+                _LOGGER.warning("login() after session reset failed during widget recovery: %s", login_err)
+                # Continue — getAulaToken might still work if cookies were partially set
+            # Step 4: fetch a fresh widget JWT against the brand-new session.
+            # We pass through _refresh_token (which would normally take the lock)
+            # but we already hold _token_refresh_lock. Use _refresh_token_locked
+            # directly to avoid deadlock.
+            return self._refresh_token_locked(widgetid, force=True)
 
     def reset_session(self) -> None:
         """Discard the HTTP session and start fresh.
@@ -202,9 +290,15 @@ class AulaProxyClient:
             self._session.set_access_token(current_token)
         # Mark logged-in as False so any next login() call re-warms the session
         self._is_logged_in = False
+        # Clear cached login result so next login() does FULL bootstrap
+        # (getProfilesByLogin + getProfileContext + getProfileMasterData),
+        # not just the quick-check shortcut. Without this, login() would early-
+        # return and skip getProfileContext, leaving the new session in a
+        # partial-bootstrap state that other API endpoints reject with 403.
+        self._login_result = None
         # Drop all cached widget tokens — they were minted against the old session
         self._tokens.clear()
-        _LOGGER.info("HTTP session reset (cookies dropped, widget cache cleared)")
+        _LOGGER.info("HTTP session reset (cookies dropped, widget cache cleared, login state reset)")
 
     def close(self) -> None:
         """Close the HTTP session."""
@@ -661,20 +755,28 @@ class AulaProxyClient:
                     continue
                 if not self._should_retry_request(response, attempt):
                     break
-            # On 401, force-refresh token once and retry this request
-            if response is not None and response.status_code == HTTPStatus.UNAUTHORIZED and not has_force_refreshed:
+            # On 401 OR HTTP 200 + {"message":"...expired..."} body, do FULL
+            # recovery (cookies + access_token + session). Upstream Aula
+            # sometimes returns the expiry signal as 401, sometimes as 200
+            # with the message in the body — we must detect both.
+            token_rejected = response is not None and (
+                response.status_code == HTTPStatus.UNAUTHORIZED
+                or self._is_widget_token_expired_body(response)
+            )
+            if token_rejected and not has_force_refreshed:
                 _LOGGER.warning(
-                    "Meebook rejected widget %s token, force-refreshing. Rejected %s. Response body: %s",
-                    widgetid, _describe_token(token), response.text[:200],
+                    "Meebook rejected widget %s token (HTTP %s). Triggering full recovery "
+                    "(cookies + OAuth + re-warm). Rejected %s. Response body: %s",
+                    widgetid, response.status_code, _describe_token(token), response.text[:200],
                 )
-                token = self._refresh_token(widgetid, force=True)
-                _LOGGER.info("After force-refresh: %s", _describe_token(token))
-                headers = self._get_meebook_header(token)
                 has_force_refreshed = True
                 try:
+                    token = self._full_recovery(widgetid)
+                    _LOGGER.info("After full recovery: %s", _describe_token(token))
+                    headers = self._get_meebook_header(token)
                     response = self._session.get(requesturl.format(weekno=weekno), headers=headers, verify=True)
                 except (RequestsTimeout, RequestsConnectionError) as e:
-                    _LOGGER.warning("Meebook retry after token refresh failed with network error: %s", e)
+                    _LOGGER.warning("Meebook retry after full recovery failed with network error: %s", e)
                     response = None
             if response == None or response.status_code != HTTPStatus.OK:
                 if response is not None:
@@ -685,9 +787,9 @@ class AulaProxyClient:
                     # Widget token failure — don't trigger main session reauth
                     if response.status_code == HTTPStatus.UNAUTHORIZED:
                         raise AulaApiError(
-                            f"Meebook widget {widgetid} returned HTTP 401 even after force-refresh "
+                            f"Meebook widget {widgetid} returned HTTP 401 even after full recovery "
                             f"({_describe_token(token)}). Response: {response.text[:200]}. "
-                            f"This usually means Aula's aulaToken endpoint is issuing tokens that Meebook rejects."
+                            f"This is a confirmed Aula server-side issue."
                         )
                     self._raise_error(response)
                 return []
@@ -758,20 +860,25 @@ class AulaProxyClient:
                             continue
                         if not self._should_retry_request(response, attempt):
                             break
-                    # On 401, force-refresh token once and retry this request
-                    if response is not None and response.status_code == HTTPStatus.UNAUTHORIZED and not has_force_refreshed:
+                    # On 401 OR 200 + 'expired' body, do FULL recovery
+                    token_rejected = response is not None and (
+                        response.status_code == HTTPStatus.UNAUTHORIZED
+                        or self._is_widget_token_expired_body(response)
+                    )
+                    if token_rejected and not has_force_refreshed:
                         _LOGGER.warning(
-                            "EasyIQ rejected widget %s token, force-refreshing. Rejected %s. Response body: %s",
-                            widgetid, _describe_token(token), response.text[:200],
+                            "EasyIQ rejected widget %s token (HTTP %s). Triggering full recovery "
+                            "(cookies + OAuth + re-warm). Rejected %s. Response body: %s",
+                            widgetid, response.status_code, _describe_token(token), response.text[:200],
                         )
-                        token = self._refresh_token(widgetid, force=True)
-                        _LOGGER.info("After force-refresh: %s", _describe_token(token))
                         has_force_refreshed = True
-                        headers = self._get_easyiq_header(token, inst_code, csrf_token)
                         try:
+                            token = self._full_recovery(widgetid)
+                            _LOGGER.info("After full recovery: %s", _describe_token(token))
+                            headers = self._get_easyiq_header(token, inst_code, csrf_token)
                             response = self._session.post(EASYIQ_API + "/weekplaninfo", json=post_data, headers=headers, verify=True)
                         except (RequestsTimeout, RequestsConnectionError) as e:
-                            _LOGGER.warning("EasyIQ retry after token refresh failed with network error: %s", e)
+                            _LOGGER.warning("EasyIQ retry after full recovery failed with network error: %s", e)
                             response = None
                     if response == None or response.status_code != HTTPStatus.OK:
                         if response is not None:
@@ -780,9 +887,9 @@ class AulaProxyClient:
                                 # Widget token failure — don't trigger main session reauth
                                 if response.status_code == HTTPStatus.UNAUTHORIZED:
                                     raise AulaApiError(
-                                        f"EasyIQ widget {widgetid} returned HTTP 401 even after force-refresh "
+                                        f"EasyIQ widget {widgetid} returned HTTP 401 even after full recovery "
                                         f"({_describe_token(token)}). Response: {response.text[:200]}. "
-                                        f"This usually means Aula's aulaToken endpoint is issuing tokens that EasyIQ rejects."
+                                        f"This is a confirmed Aula server-side issue."
                                     )
                                 self._raise_error(response)
                             continue
@@ -825,20 +932,25 @@ class AulaProxyClient:
                     continue
                 if not self._should_retry_request(response, attempt):
                     break
-            # On 401, force-refresh token once and retry this request
-            if response is not None and response.status_code == HTTPStatus.UNAUTHORIZED and not has_force_refreshed:
+            # On 401 OR 200 + 'expired' body, do FULL recovery
+            token_rejected = response is not None and (
+                response.status_code == HTTPStatus.UNAUTHORIZED
+                or self._is_widget_token_expired_body(response)
+            )
+            if token_rejected and not has_force_refreshed:
                 _LOGGER.warning(
-                    "MinUddannelse rejected widget %s token, force-refreshing. Rejected %s. Response body: %s",
-                    widgetid, _describe_token(token), response.text[:200],
+                    "MinUddannelse rejected widget %s token (HTTP %s). Triggering full recovery "
+                    "(cookies + OAuth + re-warm). Rejected %s. Response body: %s",
+                    widgetid, response.status_code, _describe_token(token), response.text[:200],
                 )
-                token = self._refresh_token(widgetid, force=True)
-                _LOGGER.info("After force-refresh: %s", _describe_token(token))
-                headers = self._get_myeducation_header(token)
                 has_force_refreshed = True
                 try:
+                    token = self._full_recovery(widgetid)
+                    _LOGGER.info("After full recovery: %s", _describe_token(token))
+                    headers = self._get_myeducation_header(token)
                     response = self._session.get(requesturl.format(weekno=weekno), headers=headers, verify=True)
                 except (RequestsTimeout, RequestsConnectionError) as e:
-                    _LOGGER.warning("MinUddannelse retry after token refresh failed with network error: %s", e)
+                    _LOGGER.warning("MinUddannelse retry after full recovery failed with network error: %s", e)
                     response = None
             if response == None or response.status_code != HTTPStatus.OK:
                 if response is not None:
@@ -847,9 +959,9 @@ class AulaProxyClient:
                         # Widget token failure — don't trigger main session reauth
                         if response.status_code == HTTPStatus.UNAUTHORIZED:
                             raise AulaApiError(
-                                f"MinUddannelse widget {widgetid} returned HTTP 401 even after force-refresh "
+                                f"MinUddannelse widget {widgetid} returned HTTP 401 even after full recovery "
                                 f"({_describe_token(token)}). Response: {response.text[:200]}. "
-                                f"This usually means Aula's aulaToken endpoint is issuing tokens that MinUddannelse rejects."
+                                f"This is a confirmed Aula server-side issue."
                             )
                         self._raise_error(response)
                 from_datetime += timedelta(weeks=1)
@@ -935,7 +1047,14 @@ class AulaProxyClient:
             return self._refresh_token_locked(widgetid, force)
 
     def _refresh_token_locked(self, widgetid:AulaWidgetId, force: bool = False) -> AulaToken | None:
-        """Fetch a fresh widget JWT, with proactive recovery from Aula's stale-cache bug.
+        """Fetch a fresh widget JWT.
+
+        Matches upstream scaarup/aula's simple behavior: fetch, cache, return.
+        We do NOT validate the JWT's exp claim — Aula sometimes issues JWTs
+        with exp earlier than iat (negative TTL), but the widget endpoint
+        is the actual authority on whether the token is acceptable. Trying
+        to second-guess Aula's exp caused regressions (session reset broke
+        unrelated endpoints).
 
         Behavior contract by mode and outcome:
 
@@ -944,34 +1063,16 @@ class AulaProxyClient:
         | HTTP non-200 from token endpoint     | evict + raise AulaApiError | log + return old token |
         | HTTP 200 + non-string `data`         | evict + raise AulaApiError | log + return old token |
         | HTTP 200 + valid JWT                 | cache + return         | cache + return         |
-        | HTTP 200 + already-expired JWT       | trigger reset+retry recovery (see below) | same |
         | Network error / JSONDecodeError      | evict + raise AulaApiError | log + return old token |
-
-        The "force returns nothing usable" rule exists to prevent silent retries
-        with stale tokens that would loop the caller into reporting "HTTP 401
-        after token refresh" when no actual refresh happened.
-
-        Stale-at-issuance recovery (proactive, runs in BOTH force modes):
-        Aula caches widget JWTs server-side keyed by HTTP session cookies.
-        When the JWT we receive is already expired, we drop the cookie jar via
-        reset_session(), warm a fresh server session via getProfilesByLogin,
-        and retry getAulaToken once. If that retry succeeds we cache+return it;
-        if it STILL returns expired, force=True raises AulaApiError and
-        force=False evicts the cache and returns None.
         """
         token = self._tokens.get(widgetid)
         current_time = datetime.now(pytz.utc)
         # Double-checked locking guard: if another thread acquired the lock
         # before us and refreshed within the last 5 minutes, reuse its result
         # rather than making a redundant HTTP roundtrip.
-        # 5 minutes is the dedup window — actual cache TTL is enforced by
-        # _get_token using the JWT's own exp claim (or TOKEN_EXPIRATION_TIME
-        # as fallback), NOT by this 5-minute value.
         if not force and token is not None and current_time - token.timestamp < timedelta(minutes=5):
-            jwt_still_valid = token.expires_at is None or current_time < token.expires_at - TOKEN_EXPIRY_BUFFER
-            if jwt_still_valid:
-                _LOGGER.debug("Ignoring token refresh request to avoid refreshing too often for widget id: " + widgetid)
-                return token
+            _LOGGER.debug("Ignoring token refresh request to avoid refreshing too often for widget id: " + widgetid)
+            return token
 
         url = f"{self._apiurl}?method=aulaToken.getAulaToken&widgetId={widgetid}"
         try:
@@ -1021,127 +1122,27 @@ class AulaProxyClient:
                 expires_at = _decode_jwt_exp(data),
             )
             self._tokens[widgetid] = token
-            now = datetime.now(pytz.utc)
-            if token.expires_at is not None and token.expires_at <= now:
-                # Aula's server-side bug: returned a JWT whose exp claim is
-                # already in the past. Empirically, this happens because Aula
-                # caches widget JWTs server-side keyed by HTTP session cookies
-                # (Csrfp-Token, PHPSESSID, etc.) — NOT by access_token. When
-                # the server-side session ages out, Aula keeps returning the
-                # SAME stale cached JWT no matter how many times we re-call
-                # getAulaToken with the same cookies (and even after
-                # access_token rotation, since cookies are unchanged).
-                #
-                # The only client-side recovery is to drop the cookie jar
-                # and force Aula to mint a fresh server-side session by
-                # calling profiles.getProfilesByLogin first.
-                cookie_summary = sorted(self._session.cookies.keys())
-                _LOGGER.warning(
-                    "Aula returned ALREADY-EXPIRED widget JWT for %s (exp: %s, now: %s, age: %ss, force=%s). "
-                    "Proactively resetting HTTP session and retrying — does NOT wait for downstream "
-                    "widget endpoint to reject this token first. Cookies before reset: %s. Full response: %s",
-                    widgetid, token.expires_at.isoformat(), now.isoformat(),
-                    (now - token.expires_at).total_seconds(), force,
-                    cookie_summary, str(responsedata)[:500],
-                )
-                # Proactive recovery — runs in BOTH force=True and force=False paths.
-                # Detecting expired-at-issuance ANY time we receive a JWT means we never
-                # cache or hand out a known-bad token to a downstream widget call.
-                try:
-                    # Step 1: drop cookie jar and clear all widget caches
-                    self.reset_session()
-                    # Step 2: warm the new session by calling
-                    # profiles.getProfilesByLogin — this is what causes
-                    # Aula's gateway to allocate a fresh server session
-                    # bound to the new cookies.
-                    try:
-                        warm = self._session.get(
-                            f"{self._apiurl}?method=profiles.getProfilesByLogin",
-                            verify=True,
-                        )
-                        _LOGGER.debug(
-                            "Session warmup after reset: HTTP %s, new cookies: %s",
-                            warm.status_code, sorted(self._session.cookies.keys()),
-                        )
-                    except (RequestsTimeout, RequestsConnectionError) as warm_err:
-                        _LOGGER.warning(
-                            "Session warmup after reset failed for widget %s: %s. "
-                            "Trying widget token fetch anyway.",
-                            widgetid, warm_err,
-                        )
-                    # Step 3: retry getAulaToken with fresh cookie jar
-                    retry_response = self._session.get(url, verify=True)
-                    if retry_response.status_code == HTTPStatus.OK:
-                        retry_data = retry_response.json().get("data")
-                        if isinstance(retry_data, str):
-                            retry_token = AulaToken(
-                                bearer_token = "Bearer " + retry_data,
-                                timestamp = datetime.now(pytz.utc),
-                                expires_at = _decode_jwt_exp(retry_data),
-                            )
-                            retry_now = datetime.now(pytz.utc)
-                            retry_valid = (retry_token.expires_at is None
-                                           or retry_token.expires_at > retry_now)
-                            if retry_valid:
-                                _LOGGER.info(
-                                    "Widget %s token recovered after session reset (TTL: %ss)",
-                                    widgetid,
-                                    (retry_token.expires_at - retry_now).total_seconds() if retry_token.expires_at else "undecoded",
-                                )
-                                self._tokens[widgetid] = retry_token
-                                return retry_token
-                            _LOGGER.error(
-                                "Widget %s STILL ALREADY-EXPIRED after session reset "
-                                "(new exp: %s, now: %s, age: %ss). This is a confirmed "
-                                "Aula server-side bug with no client-side workaround.",
-                                widgetid,
-                                retry_token.expires_at.isoformat() if retry_token.expires_at else "undecoded",
-                                retry_now.isoformat(),
-                                (retry_now - retry_token.expires_at).total_seconds() if retry_token.expires_at else "n/a",
-                            )
-                        else:
-                            _LOGGER.error(
-                                "Widget %s retry after session reset returned non-string "
-                                "data (type=%s, value=%s)",
-                                widgetid, type(retry_data).__name__, str(retry_data)[:200],
-                            )
-                    else:
-                        _LOGGER.error(
-                            "Widget %s retry after session reset returned HTTP %s %s. Body: %s",
-                            widgetid, retry_response.status_code, retry_response.reason,
-                            retry_response.text[:200],
-                        )
-                except (RequestsTimeout, RequestsConnectionError) as retry_err:
+            # Diagnostic logging only — we do NOT act on Aula's exp claim.
+            # The widget endpoint (Meebook/EasyIQ/MinUddannelse) is the
+            # authority on whether the token is acceptable. Aula occasionally
+            # returns JWTs with negative TTL (exp earlier than iat); attempting
+            # to detect and recover from this server-side cost us regressions
+            # in v0.2.6 (broke unrelated endpoints via session reset).
+            if token.expires_at is not None:
+                now = datetime.now(pytz.utc)
+                ttl = (token.expires_at - now).total_seconds()
+                if ttl <= 0:
                     _LOGGER.warning(
-                        "Widget %s retry after session reset failed with network error: %s",
-                        widgetid, retry_err,
+                        "Aula returned widget %s JWT with non-positive TTL (exp: %s, now: %s, age: %.0fs). "
+                        "Widget call will likely fail. This is a known Aula server-side issue — "
+                        "the integration cannot work around it.",
+                        widgetid, token.expires_at.isoformat(), now.isoformat(), -ttl,
                     )
-                # We tried our best; flag loudly that this is server-side.
-                # In force=True mode, raise so caller knows refresh failed.
-                # In force=False mode, evict the bad token and return None
-                # so the caller can decide what to do (typically: skip widget call).
-                _LOGGER.error(
-                    "Aula issued an ALREADY-EXPIRED widget JWT for %s (exp: %s, now: %s, age: %ss). "
-                    "This is an Aula server-side bug — the widget endpoint will reject this token. "
-                    "If this persists, please report to the integration maintainers.",
-                    widgetid, token.expires_at.isoformat(), now.isoformat(),
-                    (now - token.expires_at).total_seconds(),
-                )
-                # Evict the bad token from cache so we don't keep handing it out
-                self._tokens.pop(widgetid, None)
-                if force:
-                    raise AulaApiError(
-                        f"Widget {widgetid}: Aula returned an already-expired JWT even after "
-                        f"session reset (exp: {token.expires_at.isoformat()}, age: "
-                        f"{(now - token.expires_at).total_seconds():.0f}s). Aula server-side bug."
+                else:
+                    _LOGGER.debug(
+                        "Widget %s token refreshed, JWT exp: %s (TTL: %.0fs)",
+                        widgetid, token.expires_at.isoformat(), ttl,
                     )
-                return None
-            elif token.expires_at is not None:
-                _LOGGER.debug(
-                    "Widget %s token refreshed, JWT exp: %s (TTL: %ss)",
-                    widgetid, token.expires_at.isoformat(),
-                    (token.expires_at - now).total_seconds(),
-                )
             return token
         except (RequestsTimeout, RequestsConnectionError, ConnectionError, json.JSONDecodeError, KeyError) as e:
             # ConnectionError is raised by _retry_on_401 on transient main-session refresh failure.
@@ -1157,27 +1158,22 @@ class AulaProxyClient:
             return token
 
     def _get_token(self, widgetid:AulaWidgetId) -> AulaToken | None:
-        """Return a cached widget token if still valid, else refresh.
+        """Return a cached widget token if still within wall-clock cache window,
+        else refresh.
 
-        Uses the JWT's actual exp claim (with a small safety buffer) when
-        available — this prevents serving tokens that the server considers
-        expired even if our wall-clock cache window has not elapsed.
-        Falls back to TOKEN_EXPIRATION_TIME when the JWT cannot be decoded.
+        Uses ONLY the wall-clock cache (not JWT exp) to match upstream
+        scaarup/aula behavior. Aula occasionally returns JWTs with broken
+        exp claims (negative TTL) — we let the widget endpoint be the
+        authority on token validity rather than rejecting tokens client-side.
+
+        Use dict.get() instead of `in` + [] to avoid a KeyError race when
+        another thread mutates self._tokens between the check and the access.
         """
         _LOGGER.debug(f"Requesting new token for widget {widgetid}")
-        # Use dict.get() instead of `in` + [] to avoid a KeyError race when
-        # another thread runs reset_session() between the check and the access.
-        # _refresh_token_locked already uses the same pattern.
         token = self._tokens.get(widgetid)
         if token is not None:
             current_time = datetime.now(pytz.utc)
-            if token.expires_at is not None:
-                # Trust the JWT's own exp claim — refresh slightly before it
-                if current_time < token.expires_at - TOKEN_EXPIRY_BUFFER:
-                    _LOGGER.debug("Reusing existing token for widget %s (exp: %s)", widgetid, token.expires_at.isoformat())
-                    return token
-            elif current_time - token.timestamp < TOKEN_EXPIRATION_TIME:
-                # JWT exp not parseable — fall back to fixed cache window
+            if current_time - token.timestamp < TOKEN_EXPIRATION_TIME:
                 _LOGGER.debug("Reusing existing token for widget " + widgetid)
                 return token
         return self._refresh_token(widgetid)

--- a/custom_components/aula/aula_proxy/test_error_handling.py
+++ b/custom_components/aula/aula_proxy/test_error_handling.py
@@ -355,73 +355,6 @@ class TestJwtExpDecoding(unittest.TestCase):
         self.assertIsNone(_decode_jwt_exp(_make_jwt(-1)))
         self.assertIsNone(_decode_jwt_exp(_make_jwt(0)))
 
-    def test_already_expired_jwt_triggers_session_reset_retry(self):
-        """When force-refresh returns an expired JWT, reset session + warmup + retry once.
-
-        This tests the actual fix for the user-reported issue: Aula caches widget JWTs
-        server-side keyed by HTTP session cookies. Resetting the session forces Aula
-        to mint a brand-new server session with a fresh widget JWT.
-        """
-        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
-        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
-
-        client = AulaProxyClient("test-token")
-        client._apiurl = "https://example.com/api/v1"
-
-        # First call returns already-expired JWT (Aula's stale cache)
-        # Second call (warmup) returns OK
-        # Third call (retry getAulaToken with fresh cookies) returns fresh JWT
-        expired_jwt = _make_jwt(int(time.time()) - 1000)
-        fresh_jwt = _make_jwt(int(time.time()) + 3600)
-        responses = [
-            _make_response(200, {"data": expired_jwt}),         # initial
-            _make_response(200, {"status": {"message": "OK"}}), # warmup
-            _make_response(200, {"data": fresh_jwt}),           # retry
-        ]
-        # Patch get on the proxy class so it follows the session swap inside reset_session
-        with patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
-                   side_effect=responses) as mock_get:
-            token = client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=True)
-
-        # The fresh token from the retry must be returned and cached
-        self.assertIsNotNone(token)
-        self.assertEqual(token.bearer_token, f"Bearer {fresh_jwt}")
-        # Verify all 3 HTTP calls happened: initial + warmup + retry
-        self.assertEqual(mock_get.call_count, 3)
-
-    def test_still_expired_after_session_reset_logs_error(self):
-        """If retry after session reset STILL returns expired JWT, raise + log confirmed Aula bug."""
-        from custom_components.aula.aula_proxy.aula_errors import AulaApiError
-        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
-        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
-
-        client = AulaProxyClient("test-token")
-        client._apiurl = "https://example.com/api/v1"
-
-        expired_jwt = _make_jwt(int(time.time()) - 1000)
-        # Initial returns expired, warmup OK, retry STILL returns expired
-        responses = [
-            _make_response(200, {"data": expired_jwt}),         # initial
-            _make_response(200, {"status": {"message": "OK"}}), # warmup
-            _make_response(200, {"data": expired_jwt}),         # retry — still stale
-        ]
-        with patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
-                   side_effect=responses):
-            with self.assertLogs("custom_components.aula.aula_proxy.aula_proxy_client", level="ERROR") as cm:
-                # In force=True mode, persistent stale must raise AulaApiError
-                with self.assertRaises(AulaApiError):
-                    client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=True)
-
-        # Loud ERROR logs must be present so user knows it's confirmed Aula bug
-        self.assertTrue(
-            any("STILL ALREADY-EXPIRED after session reset" in msg for msg in cm.output),
-            f"Expected loud ERROR about persistent expired JWT after reset, got: {cm.output}",
-        )
-        self.assertTrue(
-            any("confirmed Aula server-side bug" in msg for msg in cm.output),
-            f"Expected confirmation message, got: {cm.output}",
-        )
-
     def test_reset_session_preserves_access_token_and_clears_caches(self):
         """reset_session must drop cookies + widget cache but keep the access_token."""
         from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
@@ -455,11 +388,75 @@ class TestJwtExpDecoding(unittest.TestCase):
         # Logged-in flag reset so next login() re-warms
         self.assertFalse(client._is_logged_in)
 
-    def test_proactive_session_reset_on_non_force_path(self):
-        """Even on initial _refresh_token (force=False), reset+retry on stale-at-issuance.
+    def test_get_token_uses_wallclock_cache_only(self):
+        """_get_token uses wall-clock cache only — does NOT validate JWT exp.
 
-        This is the proactive case — we detect Aula's stale JWT BEFORE handing it
-        downstream to Meebook, so the user never sees a Meebook 401.
+        Matches upstream scaarup/aula. Aula occasionally returns JWTs with
+        broken exp (negative TTL); the widget endpoint is the authority on
+        validity, not us. Validating exp client-side caused regressions.
+        """
+        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
+        from custom_components.aula.aula_proxy.models.aula_profile_models import AulaToken
+        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+        from datetime import datetime, timedelta
+        import pytz
+
+        client = AulaProxyClient("test-token")
+        client._apiurl = "https://example.com/api/v1"
+        # Cached token has exp 1 second in the past, but timestamp is fresh.
+        # Wall-clock cache says "still valid" — we must reuse it.
+        cached = AulaToken(
+            bearer_token="Bearer cached-but-jwt-expired",
+            timestamp=datetime.now(pytz.utc) - timedelta(seconds=10),
+            expires_at=datetime.now(pytz.utc) - timedelta(seconds=1),  # JWT-expired
+        )
+        client._tokens[AulaWidgetId.WEEKPLAN_PARENTS] = cached
+
+        with patch.object(client._session, "get") as mock_get:
+            result = client._get_token(AulaWidgetId.WEEKPLAN_PARENTS)
+        # Returns the cached token despite JWT exp being in the past
+        self.assertIs(result, cached)
+        mock_get.assert_not_called()
+
+    def test_full_recovery_cookies_oauth_login_widget_token(self):
+        """_full_recovery resets cookies, refreshes OAuth, calls login(), fetches new widget JWT.
+
+        Mirrors upstream scaarup/aula PR #341 working approach: drop session
+        cookies + force-refresh OAuth access_token + re-warm Aula session +
+        fetch fresh widget JWT against the brand-new server session.
+        """
+        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
+        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+
+        client = AulaProxyClient("test-token")
+        client._apiurl = "https://example.com/api/v1"
+        # Inject some stale cookies that should be dropped by full_recovery
+        client._session.cookies.set("Csrfp-Token", "old")
+        client._session.cookies.set("PHPSESSID", "old")
+
+        # Set up callback that returns True (OAuth refresh succeeded)
+        callback = Mock(return_value=True)
+        client.set_token_refresh_callback(callback)
+
+        # Mock login() to succeed without HTTP
+        fresh_jwt = _make_jwt(int(time.time()) + 3600)
+        with patch.object(AulaProxyClient, "login", return_value=Mock()) as mock_login, \
+             patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
+                   return_value=_make_response(200, {"data": fresh_jwt})):
+            token = client._full_recovery(AulaWidgetId.WEEKPLAN_PARENTS)
+
+        # Verify: callback called (OAuth refresh), login called (re-warm), fresh token returned
+        callback.assert_called_once()
+        mock_login.assert_called_once()
+        self.assertIsNotNone(token)
+        self.assertEqual(token.bearer_token, f"Bearer {fresh_jwt}")
+        # Cookies were dropped by reset_session() inside full_recovery
+        self.assertEqual(len(client._session.cookies), 0)
+
+    def test_full_recovery_propagates_credential_error(self):
+        """If OAuth refresh raises AulaCredentialError, _full_recovery propagates it.
+
+        Genuine credential failure must trigger HA reauth — never swallowed.
         """
         from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
         from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
@@ -467,118 +464,64 @@ class TestJwtExpDecoding(unittest.TestCase):
         client = AulaProxyClient("test-token")
         client._apiurl = "https://example.com/api/v1"
 
-        expired_jwt = _make_jwt(int(time.time()) - 1000)
+        # Callback raises AulaCredentialError (refresh_token expired)
+        callback = Mock(side_effect=AulaCredentialError("refresh token expired"))
+        client.set_token_refresh_callback(callback)
+
+        with self.assertRaises(AulaCredentialError):
+            client._full_recovery(AulaWidgetId.WEEKPLAN_PARENTS)
+
+    def test_full_recovery_continues_when_oauth_refresh_returns_false(self):
+        """OAuth refresh returning False (transient) should not block recovery."""
+        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
+        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+
+        client = AulaProxyClient("test-token")
+        client._apiurl = "https://example.com/api/v1"
+
+        callback = Mock(return_value=False)  # transient OAuth failure
+        client.set_token_refresh_callback(callback)
+
         fresh_jwt = _make_jwt(int(time.time()) + 3600)
-        responses = [
-            _make_response(200, {"data": expired_jwt}),         # initial — stale
-            _make_response(200, {"status": {"message": "OK"}}), # warmup
-            _make_response(200, {"data": fresh_jwt}),           # retry — fresh
-        ]
-        # Call with force=False (the proactive path — initial cache miss)
-        with patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
-                   side_effect=responses):
-            token = client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=False)
+        with patch.object(AulaProxyClient, "login", return_value=Mock()), \
+             patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
+                   return_value=_make_response(200, {"data": fresh_jwt})):
+            with self.assertLogs("custom_components.aula.aula_proxy.aula_proxy_client", level="WARNING") as cm:
+                token = client._full_recovery(AulaWidgetId.WEEKPLAN_PARENTS)
 
-        # Even without force, the recovery ran and returned the fresh token
         self.assertIsNotNone(token)
-        self.assertEqual(token.bearer_token, f"Bearer {fresh_jwt}")
+        self.assertTrue(any("OAuth access_token refresh returned False" in msg for msg in cm.output))
 
-    def test_non_force_persistent_stale_returns_none(self):
-        """If even after reset+retry the token is stale, non-force returns None (cache evicted)."""
+    def test_is_widget_token_expired_body_detects_expired_message(self):
+        """200 OK + {'message': '...expired...'} body must be detected as expired token."""
         from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
-        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+        resp = _make_response(200, {"message": "JWT-Token expired, please renew."})
+        self.assertTrue(AulaProxyClient._is_widget_token_expired_body(resp))
 
-        client = AulaProxyClient("test-token")
-        client._apiurl = "https://example.com/api/v1"
-
-        expired_jwt = _make_jwt(int(time.time()) - 1000)
-        responses = [
-            _make_response(200, {"data": expired_jwt}),         # initial
-            _make_response(200, {"status": {"message": "OK"}}), # warmup
-            _make_response(200, {"data": expired_jwt}),         # retry — STILL stale
-        ]
-        with patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
-                   side_effect=responses):
-            token = client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=False)
-
-        # Non-force returns None and evicts cache (caller can decide what to do)
-        self.assertIsNone(token)
-        self.assertNotIn(AulaWidgetId.WEEKPLAN_PARENTS, client._tokens)
-
-    def test_force_persistent_stale_raises(self):
-        """In force=True, persistent stale must raise so caller propagates the error."""
-        from custom_components.aula.aula_proxy.aula_errors import AulaApiError
+    def test_is_widget_token_expired_body_normal_response_returns_false(self):
+        """200 OK + valid widget data must NOT be detected as expired."""
         from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
-        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+        resp = _make_response(200, [{"week": "2026-W01", "data": "valid"}])
+        self.assertFalse(AulaProxyClient._is_widget_token_expired_body(resp))
 
-        client = AulaProxyClient("test-token")
-        client._apiurl = "https://example.com/api/v1"
-
-        expired_jwt = _make_jwt(int(time.time()) - 1000)
-        responses = [
-            _make_response(200, {"data": expired_jwt}),
-            _make_response(200, {"status": {"message": "OK"}}),
-            _make_response(200, {"data": expired_jwt}),  # still stale
-        ]
-        with patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
-                   side_effect=responses):
-            with self.assertRaises(AulaApiError) as ctx:
-                client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=True)
-        self.assertIn("already-expired", str(ctx.exception))
-        self.assertIn("session reset", str(ctx.exception))
-
-    def test_session_reset_warmup_failure_still_attempts_retry(self):
-        """If session warmup fails (network), still try the widget refresh — Aula may accept it."""
+    def test_is_widget_token_expired_body_non_200_returns_false(self):
+        """401/500 must NOT be classified as 'expired body' — they're handled separately."""
         from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
-        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+        self.assertFalse(AulaProxyClient._is_widget_token_expired_body(_make_response(401, {"message": "expired"})))
+        self.assertFalse(AulaProxyClient._is_widget_token_expired_body(_make_response(500)))
+        self.assertFalse(AulaProxyClient._is_widget_token_expired_body(None))
 
-        client = AulaProxyClient("test-token")
-        client._apiurl = "https://example.com/api/v1"
-
-        expired_jwt = _make_jwt(int(time.time()) - 1000)
-        fresh_jwt = _make_jwt(int(time.time()) + 3600)
-        responses = [
-            _make_response(200, {"data": expired_jwt}),         # initial
-            RequestsTimeout("warmup timeout"),                   # warmup fails
-            _make_response(200, {"data": fresh_jwt}),           # retry succeeds anyway
-        ]
-        with patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
-                   side_effect=responses):
-            token = client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=True)
-
-        # Recovery still succeeded despite warmup failure
-        self.assertIsNotNone(token)
-        self.assertEqual(token.bearer_token, f"Bearer {fresh_jwt}")
-
-    def test_already_expired_jwt_logged_as_error(self):
-        """Aula returning a JWT that's already expired must be logged loudly as an Aula server bug."""
-        from custom_components.aula.aula_proxy.aula_errors import AulaApiError
+    def test_is_widget_token_expired_body_handles_malformed_body(self):
+        """Non-JSON or non-dict bodies must not crash."""
         from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
-        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+        resp = Mock(spec=Response)
+        resp.status_code = 200
+        resp.json = Mock(side_effect=json.JSONDecodeError("", "", 0))
+        self.assertFalse(AulaProxyClient._is_widget_token_expired_body(resp))
 
-        client = AulaProxyClient("test-token")
-        client._apiurl = "https://example.com/api/v1"
-        # All 3 calls (initial + warmup + retry) return expired tokens
-        expired_jwt = _make_jwt(int(time.time()) - 60)
-        responses = [
-            _make_response(200, {"data": expired_jwt}),
-            _make_response(200, {"status": {"message": "OK"}}),
-            _make_response(200, {"data": expired_jwt}),
-        ]
-
-        with patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
-                   side_effect=responses):
-            with self.assertLogs("custom_components.aula.aula_proxy.aula_proxy_client", level="ERROR") as cm:
-                # Force=True: must raise after recovery fails
-                with self.assertRaises(AulaApiError):
-                    client._refresh_token(AulaWidgetId.WEEKPLAN_PARENTS, force=True)
-        # Errors must be logged loudly enough to identify the cause
-        self.assertTrue(any("ALREADY-EXPIRED" in msg for msg in cm.output))
-        self.assertTrue(any("Aula server-side bug" in msg for msg in cm.output))
-
-    def test_get_token_uses_jwt_exp_for_cache_invalidation(self):
-        """If JWT exp has passed, _get_token must refresh — not return cached."""
-        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
+    def test_full_recovery_cooldown_skips_when_recent(self):
+        """Recovery cooldown must prevent OAuth churn during persistent Aula outages."""
+        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient, RECOVERY_COOLDOWN
         from custom_components.aula.aula_proxy.models.aula_profile_models import AulaToken
         from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
         from datetime import datetime, timedelta
@@ -586,46 +529,127 @@ class TestJwtExpDecoding(unittest.TestCase):
 
         client = AulaProxyClient("test-token")
         client._apiurl = "https://example.com/api/v1"
-        # Cached token: timestamp is fresh (5s ago) but JWT exp was 1 second ago
-        expired_jwt_exp = datetime.now(pytz.utc) - timedelta(seconds=1)
-        client._tokens[AulaWidgetId.WEEKPLAN_PARENTS] = AulaToken(
-            bearer_token="Bearer expired",
-            timestamp=datetime.now(pytz.utc) - timedelta(seconds=5),
-            expires_at=expired_jwt_exp,
-        )
-
-        # _get_token should not return the expired token — it should call _refresh_token
-        new_jwt = _make_jwt(int(time.time()) + 3600)
-        resp = _make_response(200, {"data": new_jwt})
-        with patch.object(client._session, "get", return_value=resp):
-            result = client._get_token(AulaWidgetId.WEEKPLAN_PARENTS)
-        self.assertIsNotNone(result)
-        self.assertEqual(result.bearer_token, f"Bearer {new_jwt}")
-        self.assertIsNotNone(result.expires_at)
-
-    def test_get_token_reuses_cached_token_when_jwt_exp_is_future(self):
-        """If JWT exp is comfortably in the future, _get_token returns cached without HTTP call."""
-        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
-        from custom_components.aula.aula_proxy.models.aula_profile_models import AulaToken
-        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
-        from datetime import datetime, timedelta
-        import pytz
-
-        client = AulaProxyClient("test-token")
-        client._apiurl = "https://example.com/api/v1"
-        # JWT exp is 1 hour in the future — cache should be reused
-        future_exp = datetime.now(pytz.utc) + timedelta(hours=1)
-        cached = AulaToken(
-            bearer_token="Bearer cached",
+        # Simulate recent recovery
+        client._last_recovery_at = datetime.now(pytz.utc) - timedelta(seconds=30)
+        # Seed a stale token
+        stale_token = AulaToken(
+            bearer_token="Bearer stale",
             timestamp=datetime.now(pytz.utc),
-            expires_at=future_exp,
+            expires_at=None,
         )
-        client._tokens[AulaWidgetId.WEEKPLAN_PARENTS] = cached
+        client._tokens[AulaWidgetId.WEEKPLAN_PARENTS] = stale_token
 
-        with patch.object(client._session, "get") as mock_get:
-            result = client._get_token(AulaWidgetId.WEEKPLAN_PARENTS)
-        self.assertIs(result, cached)
-        mock_get.assert_not_called()
+        callback = Mock(return_value=True)
+        client.set_token_refresh_callback(callback)
+
+        with self.assertLogs("custom_components.aula.aula_proxy.aula_proxy_client", level="WARNING") as cm:
+            result = client._full_recovery(AulaWidgetId.WEEKPLAN_PARENTS)
+
+        # Cooldown skipped recovery — returns the cached token
+        self.assertIs(result, stale_token)
+        # Callback was NOT called (no OAuth churn)
+        callback.assert_not_called()
+        # Loud warning about skipping
+        self.assertTrue(any("Skipping full recovery" in msg for msg in cm.output))
+
+    def test_full_recovery_cooldown_allows_after_window(self):
+        """After cooldown window, recovery proceeds normally."""
+        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient, RECOVERY_COOLDOWN
+        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+        from datetime import datetime, timedelta
+        import pytz
+
+        client = AulaProxyClient("test-token")
+        client._apiurl = "https://example.com/api/v1"
+        # Last recovery older than cooldown
+        client._last_recovery_at = datetime.now(pytz.utc) - RECOVERY_COOLDOWN - timedelta(seconds=10)
+        client.set_token_refresh_callback(Mock(return_value=True))
+
+        fresh_jwt = _make_jwt(int(time.time()) + 3600)
+        with patch.object(AulaProxyClient, "login", return_value=Mock()), \
+             patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
+                   return_value=_make_response(200, {"data": fresh_jwt})):
+            token = client._full_recovery(AulaWidgetId.WEEKPLAN_PARENTS)
+
+        self.assertIsNotNone(token)
+        # _last_recovery_at was updated to now
+        now = datetime.now(pytz.utc)
+        self.assertLess((now - client._last_recovery_at).total_seconds(), 5)
+
+    def test_reset_session_clears_login_result(self):
+        """reset_session must clear _login_result so next login() does FULL bootstrap."""
+        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
+        from custom_components.aula.aula_proxy.models.aula_profile_models import AulaLoginData
+
+        client = AulaProxyClient("test-token")
+        client._login_result = AulaLoginData(api_version=19, profiles=[], widgets=[])
+        client._is_logged_in = True
+
+        client.reset_session()
+
+        self.assertIsNone(client._login_result)
+        self.assertFalse(client._is_logged_in)
+
+    def test_full_recovery_concurrent_calls_serialized(self):
+        """Two concurrent _full_recovery calls must serialize via _token_refresh_lock.
+
+        Without locking, both threads would do session reset + OAuth refresh + login
+        in parallel — wasted work and potential race conditions.
+        """
+        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
+        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+
+        client = AulaProxyClient("test-token")
+        client._apiurl = "https://example.com/api/v1"
+        callback_count = 0
+        callback_lock = threading.Lock()
+
+        def slow_callback():
+            nonlocal callback_count
+            with callback_lock:
+                callback_count += 1
+            time.sleep(0.05)
+            return True
+        client.set_token_refresh_callback(slow_callback)
+
+        fresh_jwt = _make_jwt(int(time.time()) + 3600)
+        with patch.object(AulaProxyClient, "login", return_value=Mock()), \
+             patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
+                   return_value=_make_response(200, {"data": fresh_jwt})):
+
+            def run():
+                client._full_recovery(AulaWidgetId.WEEKPLAN_PARENTS)
+
+            t1 = threading.Thread(target=run)
+            t2 = threading.Thread(target=run)
+            t1.start()
+            t2.start()
+            t1.join(timeout=5)
+            t2.join(timeout=5)
+
+        # Second thread sees the cooldown set by the first → only one OAuth call happens
+        self.assertEqual(callback_count, 1)
+
+    def test_full_recovery_continues_when_login_fails(self):
+        """If login() fails after reset, still try to fetch widget JWT."""
+        from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
+        from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
+
+        client = AulaProxyClient("test-token")
+        client._apiurl = "https://example.com/api/v1"
+
+        client.set_token_refresh_callback(Mock(return_value=True))
+
+        fresh_jwt = _make_jwt(int(time.time()) + 3600)
+        with patch.object(AulaProxyClient, "login", side_effect=ConnectionError("network")), \
+             patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
+                   return_value=_make_response(200, {"data": fresh_jwt})):
+            with self.assertLogs("custom_components.aula.aula_proxy.aula_proxy_client", level="WARNING") as cm:
+                token = client._full_recovery(AulaWidgetId.WEEKPLAN_PARENTS)
+
+        # Recovery still produced a token despite login failure
+        self.assertIsNotNone(token)
+        self.assertTrue(any("login() after session reset failed" in msg for msg in cm.output))
 
     def test_get_token_race_with_concurrent_clear_does_not_keyerror(self):
         """_get_token must use dict.get() so it doesn't KeyError if another thread
@@ -720,8 +744,8 @@ class TestJwtExpDecoding(unittest.TestCase):
         # Ideally call_count == 1; allow up to 1 due to the double-check pattern
         self.assertEqual(call_count, 1, "Lock + double-check should serialize to a single HTTP refresh")
 
-    def test_get_token_falls_back_to_timestamp_when_no_jwt_exp(self):
-        """When JWT exp can't be parsed, fall back to TOKEN_EXPIRATION_TIME wall-clock window."""
+    def test_get_token_uses_wallclock_cache_within_window(self):
+        """Cache is used while within TOKEN_EXPIRATION_TIME wall-clock window."""
         from custom_components.aula.aula_proxy.aula_proxy_client import AulaProxyClient
         from custom_components.aula.aula_proxy.models.aula_profile_models import AulaToken
         from custom_components.aula.aula_proxy.models.constants import AulaWidgetId
@@ -730,10 +754,10 @@ class TestJwtExpDecoding(unittest.TestCase):
 
         client = AulaProxyClient("test-token")
         client._apiurl = "https://example.com/api/v1"
-        # No expires_at — fall back to wall-clock cache
+        # 2 min old — well within the 5-min cache window
         cached = AulaToken(
             bearer_token="Bearer cached",
-            timestamp=datetime.now(pytz.utc) - timedelta(minutes=5),  # 5 min old, still within 40min window
+            timestamp=datetime.now(pytz.utc) - timedelta(minutes=2),
             expires_at=None,
         )
         client._tokens[AulaWidgetId.WEEKPLAN_PARENTS] = cached
@@ -931,7 +955,17 @@ class TestWidgetRecoveryCycle(unittest.TestCase):
         self.assertNotIn(widgetid, client._tokens,
                          "stale token must be evicted on force-refresh failure")
 
-        # Phase 2: simulate next poll — Aula endpoint recovered, widget returns data
+        # Phase 2: simulate next poll — Aula endpoint recovered, widget returns data.
+        # Real coordinator polls always call login() first, which re-establishes
+        # _login_result (cleared by phase 1's reset_session).
+        from custom_components.aula.aula_proxy.models.aula_profile_models import AulaLoginData, AulaWidget
+        client._login_result = AulaLoginData(
+            api_version=19,
+            profiles=[],
+            widgets=[AulaWidget(id=1, name="Meebook", widget_id=AulaWidgetId.WEEKPLAN_PARENTS)],
+        )
+        client._is_logged_in = True
+
         fresh_jwt = _make_jwt(int(time.time()) + 3600)
         def phase2_response(url, *args, **kwargs):
             if "aulaToken.getAulaToken" in url:

--- a/custom_components/aula/aula_proxy/test_error_handling.py
+++ b/custom_components/aula/aula_proxy/test_error_handling.py
@@ -934,13 +934,18 @@ class TestWidgetRecoveryCycle(unittest.TestCase):
         from_dt = datetime(2026, 4, 1, 12, 0, tzinfo=pytz.utc)
         to_dt = datetime(2026, 4, 3, 12, 0, tzinfo=pytz.utc)
 
-        # Phase 1: widget rejects token → getAulaToken also fails → cascade
-        def phase1_response(url, *args, **kwargs):
+        # Phase 1: widget rejects token → getAulaToken also fails → cascade.
+        # Patch on the _TokenSession CLASS (not instance) so the mock survives
+        # reset_session() inside _full_recovery (which creates a new instance).
+        def phase1_response(self_or_url, *args, **kwargs):
+            # When called as bound method, first arg is self; URL is in args[0] or kwargs
+            url = self_or_url if isinstance(self_or_url, str) else (args[0] if args else kwargs.get("url", ""))
             if "aulaToken.getAulaToken" in url:
                 return _make_response(500, text="Aula token endpoint down")
             return _make_response(401, text='{"message":"JWT-Token expired, please renew."}')
 
-        with patch.object(client._session, "get", side_effect=phase1_response):
+        with patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
+                   side_effect=phase1_response, autospec=True):
             with self.assertRaises(AulaApiError) as ctx:
                 client.get_weekly_plans([child], from_dt, to_dt)
 
@@ -967,12 +972,14 @@ class TestWidgetRecoveryCycle(unittest.TestCase):
         client._is_logged_in = True
 
         fresh_jwt = _make_jwt(int(time.time()) + 3600)
-        def phase2_response(url, *args, **kwargs):
+        def phase2_response(self_or_url, *args, **kwargs):
+            url = self_or_url if isinstance(self_or_url, str) else (args[0] if args else kwargs.get("url", ""))
             if "aulaToken.getAulaToken" in url:
                 return _make_response(200, {"data": fresh_jwt})
             return _make_response(200, [])  # empty weekly plans list — no fixture needed
 
-        with patch.object(client._session, "get", side_effect=phase2_response):
+        with patch("custom_components.aula.aula_proxy.aula_proxy_client._TokenSession.get",
+                   side_effect=phase2_response, autospec=True):
             plans = client.get_weekly_plans([child], from_dt, to_dt)
 
         # Cache is repopulated with the fresh token (with decoded JWT exp)


### PR DESCRIPTION
Fixes #2

## Summary

User reports show v0.2.6's proactive JWT exp validation + session reset caused regressions: 403 errors on `presence.getDailyOverview`, `messaging.getThreads`, `notifications.getNotificationsForActiveProfile` because `reset_session` dropped cookies but preserved access_token, leaving Aula's main session in a partial state.

This rewrite mirrors upstream [scaarup/aula PR #341](https://github.com/scaarup/aula/pull/341)'s working approach (verified by independent user @Dokport on 2026-04-21).

## Root cause (verified by 3 independent investigations)

Aula's server-side widget JWT cache is keyed by HTTP session cookies, **NOT** by access_token. Recovery requires rotating BOTH. Three forks (scaarup/aula, Jogge/aula, HairingX/aula) converged on this same conclusion.

## What was reverted from v0.2.6

- `_decode_jwt_exp` validation in `_get_token` — Aula occasionally issues JWTs with negative TTL; rejecting client-side hid them from the widget endpoint which is the actual authority
- Stale-at-issuance detection in `_refresh_token_locked` — proactive but based on wrong assumption
- Auto-trigger `reset_session` on JWT exp claims — caused the 403 regressions
- 40-min `TOKEN_EXPIRATION_TIME` → reduced to 5 min (matches coordinator polling)

## What was added

`_full_recovery()` mirrors upstream's working 4-step sequence:

1. `reset_session()` — drop cookies, clear widget cache, clear `_login_result`
2. `_token_refresh_callback()` — silent OAuth access_token refresh (**no MitID prompt**)
3. `login()` — re-warm Aula session via `getProfilesByLogin` + full bootstrap
4. `_refresh_token_locked(force=True)` — fresh widget JWT against new session

Triggered by widget endpoint returning **HTTP 401** OR **HTTP 200 with `{"message":"...expired..."}` body** (upstream's primary trigger pattern). Detected via new `_is_widget_token_expired_body()` helper.

## Robustness improvements over upstream PR #341

| Aspect | Upstream PR #341 | This PR |
|---|---|---|
| Throttling | None — OAuth refresh every poll during outage | `RECOVERY_COOLDOWN` (10 min) prevents token churn |
| Concurrency | Race condition between widgets | `_full_recovery` wrapped in `_token_refresh_lock` |
| Login state | May skip full bootstrap | `reset_session` clears `_login_result` → full bootstrap |
| Diagnostics | Minimal | Loud logs at every state transition |
| Trigger | Body-only | Body OR HTTP 401 |

## Behavior contract

- Cache hit (within 5 min): serve cached, no HTTP
- Cache miss: simple `getAulaToken` refresh
- Widget rejects token: `_full_recovery` + retry once
- Recovery succeeds: data fetched normally
- Recovery fails (Aula bug persists): `AulaApiError` raised, sensor marks failure, **other endpoints continue working**
- During outage: at most one recovery per 10 min, no OAuth churn

## Tests

81 tests passing (8 new):
- `test_is_widget_token_expired_body_detects_expired_message`
- `test_is_widget_token_expired_body_normal_response_returns_false`
- `test_is_widget_token_expired_body_non_200_returns_false`
- `test_is_widget_token_expired_body_handles_malformed_body`
- `test_full_recovery_cooldown_skips_when_recent`
- `test_full_recovery_cooldown_allows_after_window`
- `test_reset_session_clears_login_result`
- `test_full_recovery_concurrent_calls_serialized`