### PR TITLE
Fix notification fetch crash on non-numeric institution codes (#10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,46 @@ Config Flow (Unilogin credentials)
 - **Blocking HTTP in async:** Uses `async_add_executor_job()` to run synchronous HTTP calls from async HA context.
 - **Localization:** `strings.json` with translations in `translations/en.json` and `translations/da.json`.
 
+## Release Process
+
+When the maintainer asks to "release" (or cut/publish a release), follow this exact
+process. It is split across three GitHub Actions workflows in `.github/workflows/`.
+**Two preconditions must both be satisfied before anything can be published: (1) the
+draft release must exist, and (2) the maintainer must have explicitly approved it.**
+
+1. **Draft is produced automatically — wait for it.** `release-drafter.yml` runs on every
+   push to `main` and maintains a single GitHub **draft release** whose notes are
+   auto-generated and categorized from merged PR labels (it also auto-labels PRs). After
+   the relevant changes are merged to `main`, **wait until the Release Drafter workflow run
+   has completed** so the draft reflects them. Never publish before the draft is up to date —
+   the publish step reuses the draft's body as the release notes.
+
+2. **Review and approval — mandatory, maintainer only.** Present the current draft release
+   notes to the maintainer and get **explicit approval** of the content (and the version
+   number) before proceeding. Do NOT publish a release without this approval, even if asked
+   to "just release it" — confirm the draft first.
+
+3. **Publish via the `Release` workflow (`release.yml`).** This is the action responsible for
+   the actual release. It is a manual `workflow_dispatch` taking a `version` input
+   (e.g. `0.2.6` — **without** the `v` prefix; format `X.Y.Z` or `X.Y.Z-suffix`). It then,
+   in order: validates the version, verifies tag `v$VERSION` does not already exist, bumps
+   `custom_components/aula/manifest.json` via `.github/scripts/update_hacs_manifest.py`,
+   commits the bump and pushes to `main`, creates and pushes tag `v$VERSION`, builds
+   `aula.zip` (excluding `test_*`, `__pycache__`, `*.pyc`), **captures the Release Drafter
+   draft's body as the release notes and deletes the draft**, then publishes the GitHub
+   Release for `v$VERSION` with `aula.zip` attached. The maintainer (or, if permitted, the
+   agent) triggers this workflow with the approved version number — do not bump the manifest
+   or create the tag by hand; the workflow owns version bump, tag, zip, and publish.
+
+4. **Dev/pre-releases** use a separate workflow, `release-dev.yml` (`Release dev`): a manual
+   `workflow_dispatch` taking a `tag` input (e.g. `v0.3.0-dev.1`) that builds `aula.zip` and
+   uploads it as a **prerelease** asset. Use this only when a dev/prerelease build is
+   explicitly requested; it does not bump the manifest.
+
+Summary of ownership: Release Drafter (automatic, on push to `main`) owns the draft notes →
+maintainer approves → the `Release` workflow owns version bump, tagging, zipping, and
+publishing. Build + draft must be in place, and approval given, before any release.
+
 ## Agent Workflow (MANDATORY)
 
 **All code changes MUST follow the agent workflow process defined in `docs/AGENT_WORKFLOW.md`.** This process requires every task to pass through 9 stages: Project Management → Design Document → Design Review (multi-team) → Implementation → QA Review → Performance Review → Network & Data Review → HASS Compliance → Final Verification. **NO code may be written until the design document is reviewed and approved by all specialist agent teams (Stage 3).** No stage may be skipped. Read the full process document before starting any task.

--- a/custom_components/aula/aula_proxy/models/aula_notification_models.py
+++ b/custom_components/aula/aula_proxy/models/aula_notification_models.py
@@ -62,7 +62,6 @@ class AulaGalleryNotification(AulaNotificationBase):
 
 @dataclass
 class AulaMessageNotification(AulaNotificationBase):
-    folder_id: int
     institution_code: str
     institution_profile_id: int
     message_text: str

--- a/custom_components/aula/aula_proxy/models/aula_notification_models.py
+++ b/custom_components/aula/aula_proxy/models/aula_notification_models.py
@@ -62,6 +62,13 @@ class AulaGalleryNotification(AulaNotificationBase):
 
 @dataclass
 class AulaMessageNotification(AulaNotificationBase):
+    # NOTE (issue #10): best-guess mapping pending real-world verification.
+    # The real Aula folder id is documented as Thread.folderId (int|null) on
+    # message threads; it is NOT confirmed to exist on the notification payload
+    # (the captured notifications response was empty). Sourced from "folderId"
+    # and parsed nullable + crash-safe, so it is None when absent rather than
+    # breaking the whole notification fetch.
+    folder_id: int | None
     institution_code: str
     institution_profile_id: int
     message_text: str

--- a/custom_components/aula/aula_proxy/models/aula_notification_parser.py
+++ b/custom_components/aula/aula_proxy/models/aula_notification_parser.py
@@ -40,7 +40,6 @@ class AulaNotificationParser(AulaParser):
             notification_id=AulaNotificationParser._parse_str(data.get("notificationId")),
             notification_type=AulaNotificationParser._parse_str(data.get("notificationType")),
             triggered=AulaNotificationParser._parse_datetime(data.get("triggered"), fix_timezone=True),
-            folder_id=AulaNotificationParser._parse_int(data.get("institutionCode")),  # intentional: institutionCode is used as the folder key
             institution_code=AulaNotificationParser._parse_str(data.get("institutionCode")),
             institution_profile_id=AulaNotificationParser._parse_int(data.get("institutionProfileId")),
             message_text=AulaNotificationParser._parse_str(data.get("messageText")),

--- a/custom_components/aula/aula_proxy/models/aula_notification_parser.py
+++ b/custom_components/aula/aula_proxy/models/aula_notification_parser.py
@@ -2,7 +2,6 @@ from typing import List
 import logging
 
 from ..responses.get_notifications_response import AulaGetNotificationsResponse, AulaNotificationData
-from ..utils.list_utils import list_without_none
 
 from .aula_notification_models import *
 from .aula_parser import AulaParser
@@ -40,6 +39,10 @@ class AulaNotificationParser(AulaParser):
             notification_id=AulaNotificationParser._parse_str(data.get("notificationId")),
             notification_type=AulaNotificationParser._parse_str(data.get("notificationType")),
             triggered=AulaNotificationParser._parse_datetime(data.get("triggered"), fix_timezone=True),
+            # Best guess for issue #10: the real folder id is "folderId" (int|null,
+            # as on message threads). Unverified on the notification payload, so
+            # parsed crash-safe — None when absent. Verify against a real response.
+            folder_id=AulaNotificationParser._parse_nullable_int_safe(data.get("folderId")),
             institution_code=AulaNotificationParser._parse_str(data.get("institutionCode")),
             institution_profile_id=AulaNotificationParser._parse_int(data.get("institutionProfileId")),
             message_text=AulaNotificationParser._parse_str(data.get("messageText")),
@@ -173,7 +176,18 @@ class AulaNotificationParser(AulaParser):
     @staticmethod
     def parse_notifications(data: List[AulaNotificationData] | None) -> List[AULA_NOTIFICATION_TYPES]:
         if data is None: return []
-        return list_without_none(map(AulaNotificationParser.parse_notification, data))
+        results = list[AULA_NOTIFICATION_TYPES]()
+        for item in data:
+            # Isolate per-notification parsing: a single malformed notification
+            # must not take down the whole fetch (see issue #10).
+            try:
+                notification = AulaNotificationParser.parse_notification(item)
+            except Exception as ex:
+                _LOGGER.warning(f"Failed to parse notification, skipping it: {ex}. Data: {item}")
+                continue
+            if notification is not None:
+                results.append(notification)
+        return results
 
     @staticmethod
     def parse_notification_response(data: AulaGetNotificationsResponse | None) -> List[AULA_NOTIFICATION_TYPES]:

--- a/custom_components/aula/aula_proxy/models/aula_parser.py
+++ b/custom_components/aula/aula_proxy/models/aula_parser.py
@@ -84,6 +84,21 @@ class AulaParser:
         return int(value)
 
     @staticmethod
+    def _parse_nullable_int_safe(value: Any) -> int | None:
+        """Like _parse_nullable_int but never raises on non-numeric input.
+
+        Returns None when the value is missing or cannot be interpreted as an
+        int. Use for fields whose type/presence is not yet confirmed against the
+        real API, so a surprising value cannot crash parsing (see issue #10)."""
+        if value is None: return None
+        if isinstance(value, bool): return None  # bools are ints in Python; reject them
+        if isinstance(value, int): return value
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
     def _parse_str(value: Any) -> str:
         if value is None: return ""
         return str(value)

--- a/custom_components/aula/aula_proxy/responses/get_notifications_response.py
+++ b/custom_components/aula/aula_proxy/responses/get_notifications_response.py
@@ -14,6 +14,7 @@ class AulaNotificationData(TypedDict):
     albumId: NotRequired[int|None]
     endTime: NotRequired[str|None]
     eventId: NotRequired[int|None]
+    folderId: NotRequired[int|None]  # best guess for issue #10; verify against real payload
     isAllDayEvent: NotRequired[bool|None]
     mediaId: NotRequired[int|None]
     mediaIds: NotRequired[List[int]|None]

--- a/custom_components/aula/aula_proxy/test_notifications.py
+++ b/custom_components/aula/aula_proxy/test_notifications.py
@@ -9,8 +9,8 @@ from custom_components.aula.aula_proxy.models.aula_notification_parser import (
 
 
 class TestNotifications(unittest.TestCase):
-    def _message_notification(self, institution_code: object) -> dict:
-        return {
+    def _message_notification(self, institution_code: object, **extra: object) -> dict:
+        data = {
             "expires": "2026-05-23T23:59:59+00:00",
             "institutionCode": institution_code,
             "institutionProfileId": 123456,
@@ -23,6 +23,8 @@ class TestNotifications(unittest.TestCase):
             "senderName": "Teacher",
             "threadId": 987654,
         }
+        data.update(extra)
+        return data
 
     def test_message_notification_with_non_numeric_institution_code(self):
         """Regression test for issue #10.
@@ -59,6 +61,33 @@ class TestNotifications(unittest.TestCase):
         results = AulaNotificationParser.parse_notifications(data)
 
         self.assertEqual(len(results), 2)
+
+    def test_folder_id_parsed_when_present(self):
+        """Best-guess mapping for issue #10: a numeric folderId is captured."""
+        data = self._message_notification("123456", folderId=42)
+
+        result = AulaNotificationParser.parse_notification(data)
+
+        assert isinstance(result, AulaMessageNotification)
+        self.assertEqual(result.folder_id, 42)
+
+    def test_folder_id_is_none_when_absent(self):
+        """No folderId in the payload yields None, not a crash or sentinel int."""
+        data = self._message_notification("123456")
+
+        result = AulaNotificationParser.parse_notification(data)
+
+        assert isinstance(result, AulaMessageNotification)
+        self.assertIsNone(result.folder_id)
+
+    def test_folder_id_non_numeric_does_not_crash(self):
+        """An unexpected non-numeric folderId is tolerated (None), never raises."""
+        data = self._message_notification("123456", folderId="not-a-number")
+
+        result = AulaNotificationParser.parse_notification(data)
+
+        assert isinstance(result, AulaMessageNotification)
+        self.assertIsNone(result.folder_id)
 
 
 if __name__ == "__main__":

--- a/custom_components/aula/aula_proxy/test_notifications.py
+++ b/custom_components/aula/aula_proxy/test_notifications.py
@@ -1,0 +1,65 @@
+import unittest
+
+from custom_components.aula.aula_proxy.models.aula_notification_models import (
+    AulaMessageNotification,
+)
+from custom_components.aula.aula_proxy.models.aula_notification_parser import (
+    AulaNotificationParser,
+)
+
+
+class TestNotifications(unittest.TestCase):
+    def _message_notification(self, institution_code: object) -> dict:
+        return {
+            "expires": "2026-05-23T23:59:59+00:00",
+            "institutionCode": institution_code,
+            "institutionProfileId": 123456,
+            "notificationArea": "Messages",
+            "notificationEventType": "NewMessagePrivateInbox",
+            "notificationId": "NewMessagePrivateInbox:123456:Badge",
+            "notificationType": "Badge",
+            "triggered": "2026-05-22T13:09:47+00:00",
+            "messageText": "Hello",
+            "senderName": "Teacher",
+            "threadId": 987654,
+        }
+
+    def test_message_notification_with_non_numeric_institution_code(self):
+        """Regression test for issue #10.
+
+        Aula institution codes can be non-numeric (e.g. 'GXXXXX'). Parsing a
+        message notification must not raise ValueError on such codes; previously
+        institutionCode was forced through int() and crashed the whole fetch.
+        """
+        data = self._message_notification("GXXXXX")
+
+        result = AulaNotificationParser.parse_notification(data)
+
+        self.assertIsInstance(result, AulaMessageNotification)
+        assert isinstance(result, AulaMessageNotification)
+        self.assertEqual(result.institution_code, "GXXXXX")
+
+    def test_message_notification_with_numeric_institution_code(self):
+        """A numeric institution code is preserved verbatim as a string."""
+        data = self._message_notification("123456")
+
+        result = AulaNotificationParser.parse_notification(data)
+
+        self.assertIsInstance(result, AulaMessageNotification)
+        assert isinstance(result, AulaMessageNotification)
+        self.assertEqual(result.institution_code, "123456")
+
+    def test_batch_with_one_non_numeric_code_parses_all(self):
+        """A single non-numeric institution code must not take down the batch."""
+        data = [
+            self._message_notification("GXXXXX"),
+            self._message_notification("123456"),
+        ]
+
+        results = AulaNotificationParser.parse_notifications(data)
+
+        self.assertEqual(len(results), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/api/v23/api-reference.md
+++ b/docs/api/v23/api-reference.md
@@ -69,7 +69,7 @@ Returns the logged-in user's profiles and children.
 |---|---|---|
 | `id` | int | Institution profile ID (instProfileId) |
 | `profileId` | int | Cross-institution profile ID |
-| `institutionCode` | string | e.g. "791006", "G16713" |
+| `institutionCode` | string | numeric (e.g. "791006") or letter-prefixed (e.g. "Gxxxxx") — see issue #10 |
 | `institutionName` | string | |
 | `municipalityCode` | string | e.g. "791" |
 | `municipalityName` | string | e.g. "Viborg" |


### PR DESCRIPTION
## Summary

Fixes #10 — the notification fetch crashed on every 5-minute poll with `invalid literal for int() with base 10: '<institution-code>'` (235 occurrences over ~20 hours = one per poll).

### Root cause (100% traced)
`parse_message` populated a `folder_id` field via `_parse_int(data.get("institutionCode"))`. Aula `institutionCode` is a **string** that can be non-numeric (a letter-prefixed institution code), so `int()` raised `ValueError`, which propagated up and took down the entire notification fetch. The `folder_id` value was never read anywhere downstream, and an institution code is not a folder identifier.

Two independent review agents confirmed the root cause, that `folder_id` was dead, and that no other notification `_parse_int` call targets a string-typed field.

## Changes

1. **Bugfix** — stop forcing the string `institutionCode` through `int()`. The institution value is still available losslessly via the existing `institution_code: str` field.

2. **Best-guess `folder_id` (pending verification)** — re-introduces `folder_id` sourced from the API's documented folder identifier `folderId` (`int|null`, as on `Thread` per `docs/api/v23/api-reference.md`), **not** the institution code. It is unverified on the notification payload (the captured notifications response was empty), so it is:
   - parsed with a new crash-safe `_parse_nullable_int_safe()` helper (returns `None` for missing/non-numeric, never raises), and
   - typed `int | None`, defaulting to `None` when absent.

   This lets the value be verified against a real Aula response (via web-UI traffic) without risk of re-breaking the fetch. If `folderId` turns out not to exist on notifications, the field stays `None` and the real folder id belongs on `AulaMessageThread` (`Thread.folderId`) instead.

3. **Per-notification isolation** — `parse_notifications` now isolates each item: a single malformed notification logs a warning and is skipped instead of crashing the whole fetch.

4. **Regression tests** — new `test_notifications.py` covering a non-numeric institution code (the original crash), numeric code, `folderId` present/absent/non-numeric, and batch isolation. Passes on Python 3.11 and 3.13.

5. **Docs** — added a `Release Process` section to `CLAUDE.md` describing the Release Drafter → maintainer approval → `Release` workflow flow.

## Verification
Tests pass locally (via an isolated runner mocking Home Assistant, since this environment lacks Python 3.14). Full suite runs in CI on Python 3.14.

https://claude.ai/code/session_01GVkf6mXohvjcN6L6im5Dnr